### PR TITLE
feat!: Support transient identities and traits

### DIFF
--- a/.github/workflows/publish_master.yml
+++ b/.github/workflows/publish_master.yml
@@ -4,40 +4,25 @@ on:
     tags:
       - "*"
 
+env:
+  FLUTTER_VERSION: '3.x'
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
     name: Dart Analyze
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.x'
-          channel: 'stable'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
       - run: flutter pub get
       - run: flutter analyze
 
   # TODO https://github.com/Flagsmith/flagsmith-flutter-client/issues/57
 
-  publishing:
-    runs-on: ubuntu-latest
-    container:
-      image: google/dart:latest
-    name: Dart Publish Package
-    needs: analyze
-    steps:
-      - uses: actions/checkout@v1
-      - name: Setup credentials
-        run: |
-          mkdir -p ~/.pub-cache
-          cat <<EOF > ~/.pub-cache/credentials.json
-          {
-            "accessToken":"${{ secrets.OAUTH_ACCESS_TOKEN }}",
-            "refreshToken":"${{ secrets.OAUTH_REFRESH_TOKEN }}",
-            "tokenEndpoint":"https://accounts.google.com/o/oauth2/token",
-            "scopes": [ "openid", "https://www.googleapis.com/auth/userinfo.email" ],
-            "expiration": 1649072931936
-          }
-          EOF
-      - name: Publish package
-        run: pub publish -f
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,16 +10,19 @@ on:
             - reopened
             - ready_for_review
 
+env:
+  FLUTTER_VERSION: '3.x'
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
     name: Dart Analyze
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.x'
-          channel: 'stable'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
       - run: flutter pub get
       - run: flutter analyze
 
@@ -27,14 +30,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Flutter Test
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.x'
-        channel: 'stable'
-
+        flutter-version: ${{ env.FLUTTER_VERSION }}
+        channel: stable
     - run: flutter pub get
-    - run: flutter pub test
+    - run: flutter test
 
   # TODO https://github.com/Flagsmith/flagsmith-flutter-client/issues/57
 
@@ -46,8 +48,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
       with:
-        flutter-version: '3.x'
-        channel: 'stable'
-
+        flutter-version: ${{ env.FLUTTER_VERSION }}
+        channel: stable
     - run: flutter pub publish --dry-run
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Changelog
+## [6.0.0]
+
+Breaking Changes:
+
+- Drop Flutter 2 support
+
+Features:
+
+- Support transient identities and traits
+
+Other:
+
+- Integrate `flagsmith_core` and `flagsmith_storage_sharedpreferences`
+- Minor unit test improvements
+
 ## [5.0.1]
 
 - Change the base url to https://edge.api.flagsmith.com/api/v1/

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,31 @@
+targets:
+  $default:
+    builders:
+      source_gen|combining_builder:
+        options:
+          ignore_for_file:
+            - implicit_dynamic_parameter
+            - non_constant_identifier_names
+            - type_annotate_public_apis
+            - omit_local_variable_types
+            - unnecessary_this
+      json_serializable:
+        options:
+          any_map: false
+          create_to_json: true
+          disallow_unrecognized_keys: false
+          explicit_to_json: true
+          # # Options configure how source code is generated for every
+          # # `@JsonSerializable`-annotated class in the package.
+          # #
+          # # The default value for each is listed.
+          # any_map: false
+          # checked: false
+          # create_factory: true
+          # create_to_json: true
+          # disallow_unrecognized_keys: false
+          # explicit_to_json: false
+          # field_rename: none
+          # generic_argument_factories: false
+          # ignore_unannotated: false
+          # include_if_null: true

--- a/example/lib/di.dart
+++ b/example/lib/di.dart
@@ -1,5 +1,4 @@
 import 'package:flagsmith/flagsmith.dart';
-import 'package:flagsmith_storage/flagsmith_storage_sharedpreferences.dart';
 import 'package:get_it/get_it.dart';
 
 import 'bloc/flag_bloc.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,7 +47,6 @@ ThemeData darkTheme(BuildContext context) {
       secondary: Color(0xFFBFA6E9),
       secondaryContainer: Color(0xFF9D88C0),
       surface: Color(0xFF1a1c26),
-      background: Color(0xFF1a1c26),
     ),
     textTheme: GoogleFonts.varelaRoundTextTheme(
       ThemeData.dark().textTheme,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.6.0"
   asn1lib:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: "21afe4333076c02877d14f4a89df111e658a6d466cbfc802eb705eb91bd5adfd"
+      sha256: "6b151826fcc95ff246cd219a0bf4c753ea14f4081ad71c61939becf3aba27f70"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.5"
   async:
     dependency: transitive
     description:
@@ -61,42 +61,50 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.6"
   dio:
     dependency: transitive
     description:
       name: dio
-      sha256: ce75a1b40947fea0a0e16ce73337122a86762e38b982e1ccb909daa3b9bc4197
+      sha256: "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.2"
+    version: "5.7.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "33259a9276d6cea88774a0000cfae0d861003497755969c92faa223108620dc8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   encrypt:
     dependency: transitive
     description:
       name: encrypt
-      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
+      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.3"
   equatable:
     dependency: "direct main"
     description:
@@ -117,41 +125,25 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.4"
+    version: "7.0.1"
   flagsmith:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "4.0.0"
-  flagsmith_flutter_core:
-    dependency: transitive
-    description:
-      name: flagsmith_flutter_core
-      sha256: "4e025cb80c7dbc31fbc4f0789e0fde6dd7e779fe6da328322afccdabc87d510e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
-  flagsmith_storage:
-    dependency: "direct main"
-    description:
-      name: flagsmith_storage
-      sha256: "311a611b304f387090880d90fa0aba847646bb6d41b5928cb135a92e6c5eb5ed"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
+    version: "5.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -203,10 +195,10 @@ packages:
     dependency: "direct main"
     description:
       name: get_it
-      sha256: f79870884de16d689cf9a7d15eedf31ed61d750e813c538a6efb92660fea83c3
+      sha256: d85128a5dae4ea777324730dc65edd9c9f43155c109d5cc0a69cab74139fbac1
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.4"
+    version: "7.7.0"
   google_fonts:
     dependency: "direct main"
     description:
@@ -243,18 +235,42 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
+    version: "4.9.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.5"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -267,26 +283,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   nested:
     dependency: transitive
     description:
@@ -299,10 +315,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_drawing:
     dependency: transitive
     description:
@@ -323,26 +339,26 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: a1aa8aaa2542a6bc57e381f132af822420216c80d4781f7aa085ca3229208aaa
+      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.4"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "6b8b19bd80da4f11ce91b2d1fb931f3006911477cec227cce23d3253d80df3f1"
+      sha256: c464428172cb986b758c6d1724c603097febb8fb855aa265aeecc9280c294d4a
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.12"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "19314d595120f82aca0ba62787d58dde2cc6b5df7d2f0daf72489e38d1b57f2d"
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -355,122 +371,122 @@ packages:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "94b1e0dd80970c1ce43d5d4e050a9918fce4f4a775e6142424c30a29a363265c"
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      sha256: "8bc9f22eee8690981c22aa7fc602f5c85b497a6fb2ceb35ee5a5e5ed85ad8170"
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      sha256: cb3798bef7fc021ac45b308f4b51208a152792445cce0448c9a4ba5879dd8750
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "6.0.2"
   platform:
     dependency: "direct main"
     description:
       name: platform
-      sha256: ae68c7bfcd7383af3629daafb32fb4e8681c7154428da4febcff06200585f102
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: da3fdfeccc4d4ff2da8f8c556704c08f912542c5fb3cf2233ed75372384a034d
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.8"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.3"
+    version: "3.9.1"
   provider:
     dependency: transitive
     description:
       name: provider
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.1.2"
   rxdart:
     dependency: "direct main"
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
   shared_preferences:
     dependency: transitive
     description:
       name: shared_preferences
-      sha256: "858aaa72d8f61637d64e776aca82e1c67e6d9ee07979123c5d17115031c1b13b"
+      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.2"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "8568a389334b6e83415b6aae55378e158fbc2314e074983362d20c562780fb06"
+      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.3"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "7bf53a9f2d007329ee6f3df7268fd498f8373602f943c975598bbb34649b62a7"
+      sha256: "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.5.3"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: c2eb5bf57a2fe9ad6988121609e47d3e07bb3bdca5b6f8444e4cf302428a128a
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.1"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: d4ec5fc9ebb2f2e056c617112aa75dcf92fc2e4faaf2ae999caa297473f75d8a
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.1"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
+      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.4.2"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: f763a101313bd3be87edffe0560037500967de9c394a714cd598d945517f694f
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -488,26 +504,26 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -520,10 +536,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -540,38 +556,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.3.0"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      sha256: "9e82a402b7f3d518fb9c02d0e9ae45952df31b9bf34d77baf19da2de03fc2aaa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.7"
+    version: "1.1.0"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: "589ada45ba9e39405c198fe34eb0f607cddb2108527e658136120892beac46d2"
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:
       name: xml
-      sha256: "5bc72e1e45e941d825fd7468b9b4cc3b9327942649aeb6fc5cdbf135f0a86e84"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.5.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.7.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -143,7 +143,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "5.0.1"
+    version: "6.0.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
     sdk: flutter
   flagsmith:
     path: ../
-  flagsmith_storage: ^4.0.0
 
   platform: ^3.1.0
   collection: ^1.15.0
@@ -21,7 +20,7 @@ dependencies:
   get_it: ^7.2.0
   google_fonts: ^2.3.1
   hexcolor: ^2.0.6
-  rxdart: ^0.27.5
+  rxdart: ^0.28.0
 dev_dependencies:
   flutter_lints: ^1.0.4
   flutter_test:

--- a/lib/flagsmith.dart
+++ b/lib/flagsmith.dart
@@ -3,10 +3,9 @@
 ///
 /// Flagsmith allows you to manage feature flags and remote config across multiple projects, environments and organisations.
 
-library flagsmith;
-
-export 'package:flagsmith_flutter_core/flagsmith_flutter_core.dart';
+library;
 
 export 'src/flagsmith_client.dart';
 export 'src/flagsmith_config.dart';
 export 'src/core/core.dart';
+export 'src/storage/storage.dart';

--- a/lib/src/core/core.dart
+++ b/lib/src/core/core.dart
@@ -1,5 +1,9 @@
-export 'exceptions.dart';
-
-export 'string_x.dart';
-
+export 'crud_storage.dart';
 export 'datetime_x.dart';
+export 'exceptions.dart';
+export 'extensions/converters.dart';
+export 'model/index.dart';
+export 'storage_provider.dart';
+export 'storage_type.dart';
+export 'storage/in_memory_storage.dart';
+export 'string_x.dart';

--- a/lib/src/core/crud_storage.dart
+++ b/lib/src/core/crud_storage.dart
@@ -1,0 +1,16 @@
+/// Abstract for CRUD operations over storage
+abstract class CoreStorage {
+  Future<bool> create(String key, String item);
+  Future<String?> read(String key);
+  Future<bool> update(String key, String item);
+  Future<bool> delete(String key);
+  Future<bool> clear();
+  Future<void> init();
+  Future<bool> seed(List<MapEntry<String, String>> items);
+  Future<List<String?>> getAll();
+}
+
+mixin SecureStorage {
+  Future<String?> getSecuredValue(String key);
+  Future<bool> setSecuredValue(String key, String value, {bool update = false});
+}

--- a/lib/src/core/exceptions.dart
+++ b/lib/src/core/exceptions.dart
@@ -38,5 +38,5 @@ class FlagsmithApiException extends DioException {
 /// FlagsmithConfigException
 /// - When client is misconfigured
 class FlagsmithConfigException extends FlagsmithException {
-  FlagsmithConfigException(Exception e) : super(e);
+  FlagsmithConfigException(Exception super.e);
 }

--- a/lib/src/core/extensions/converters.dart
+++ b/lib/src/core/extensions/converters.dart
@@ -1,0 +1,8 @@
+String? stringFromJson(dynamic value) => value == null ? null : '$value';
+String nonNullStringFromJson(dynamic value) => '$value';
+dynamic stringToJson(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  return value;
+}

--- a/lib/src/core/extensions/string_ext.dart
+++ b/lib/src/core/extensions/string_ext.dart
@@ -1,0 +1,3 @@
+extension StringX on String {
+  String normalize() => toLowerCase().trim().replaceAll(' ', '_');
+}

--- a/lib/src/core/model/feature.dart
+++ b/lib/src/core/model/feature.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import '../extensions/converters.dart';
+import 'package:json_annotation/json_annotation.dart';
+part 'feature.g.dart';
+
+/// Standard Flagsmith feature
+@JsonSerializable()
+class Feature {
+  final int? id;
+  final String name;
+  @JsonKey(name: 'created_date')
+  final DateTime? createdDate;
+
+  @JsonKey(
+      name: 'initial_value', fromJson: stringFromJson, toJson: stringToJson)
+  final String? initialValue;
+
+  @JsonKey(name: 'default_enabled')
+  final bool? defaultValue;
+  final String? description;
+
+  Feature({
+    this.id,
+    required this.name,
+    this.createdDate,
+    this.initialValue,
+    this.defaultValue,
+    this.description,
+  });
+  factory Feature.named({
+    int? id,
+    required String name,
+    DateTime? createdDate,
+    String? initialValue,
+    bool? defaultValue,
+    String? description,
+  }) =>
+      Feature(
+          id: id,
+          name: name,
+          createdDate: createdDate,
+          initialValue: initialValue,
+          defaultValue: defaultValue,
+          description: description);
+
+  factory Feature.fromJson(Map<String, dynamic> json) =>
+      _$FeatureFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FeatureToJson(this);
+  String asString() => jsonEncode(toJson());
+  Feature copyWith({
+    int? id,
+    String? name,
+    DateTime? createdDate,
+    String? initialValue,
+    bool? defaultValue,
+    String? description,
+  }) =>
+      Feature(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        createdDate: createdDate ?? this.createdDate,
+        initialValue: initialValue ?? this.initialValue,
+        defaultValue: defaultValue ?? this.defaultValue,
+        description: description ?? this.description,
+      );
+}

--- a/lib/src/core/model/feature.g.dart
+++ b/lib/src/core/model/feature.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, non_constant_identifier_names, type_annotate_public_apis, omit_local_variable_types, unnecessary_this
+
+part of 'feature.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Feature _$FeatureFromJson(Map<String, dynamic> json) => Feature(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String,
+      createdDate: json['created_date'] == null
+          ? null
+          : DateTime.parse(json['created_date'] as String),
+      initialValue: stringFromJson(json['initial_value']),
+      defaultValue: json['default_enabled'] as bool?,
+      description: json['description'] as String?,
+    );
+
+Map<String, dynamic> _$FeatureToJson(Feature instance) => <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'created_date': instance.createdDate?.toIso8601String(),
+      'initial_value': stringToJson(instance.initialValue),
+      'default_enabled': instance.defaultValue,
+      'description': instance.description,
+    };

--- a/lib/src/core/model/flag.dart
+++ b/lib/src/core/model/flag.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import '../extensions/converters.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'dart:math';
+
+import 'feature.dart';
+part 'flag.g.dart';
+
+@JsonSerializable()
+class Flag {
+  final int? id;
+  final Feature feature;
+  @JsonKey(
+      name: 'feature_state_value',
+      fromJson: stringFromJson,
+      toJson: stringToJson)
+  final String? stateValue;
+  final bool? enabled;
+  final int? environment;
+  final int? identity;
+  @JsonKey(name: 'feature_segment')
+  final int? featureSegment;
+  Flag(
+      {this.id,
+      required this.feature,
+      this.stateValue,
+      this.enabled,
+      this.environment,
+      this.identity,
+      this.featureSegment});
+
+  String get key => feature.name;
+  @override
+  String toString() {
+    return 'F(${feature.name}:$enabled)';
+  }
+
+  static int _generateNum(int min, int max) =>
+      min + Random().nextInt(max - min);
+  factory Flag.named(
+          {int? id,
+          required Feature feature,
+          String? stateValue,
+          bool? enabled,
+          int? environment,
+          int? identity,
+          int? featureSegment}) =>
+      Flag(
+        id: id,
+        feature: feature,
+        stateValue: stateValue,
+        enabled: enabled,
+        environment: environment,
+        identity: identity,
+        featureSegment: featureSegment,
+      );
+  factory Flag.seed(String featureName, {bool enabled = true, String? value}) {
+    var id = _generateNum(1, 100);
+
+    return Flag.named(
+        id: id,
+        stateValue: value,
+        feature: Feature.named(
+          id: id,
+          name: featureName,
+          createdDate: DateTime.now().add(
+            Duration(days: _generateNum(0, 10)),
+          ),
+          initialValue: '',
+          defaultValue: false,
+        ),
+        enabled: enabled);
+  }
+
+  factory Flag.fromJson(Map<String, dynamic> json) => _$FlagFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FlagToJson(this);
+  String asString() => jsonEncode(toJson());
+
+  Flag copyWith(
+          {int? id,
+          Feature? feature,
+          String? stateValue,
+          bool? enabled,
+          int? environment,
+          int? identity,
+          int? featureSegment}) =>
+      Flag(
+        id: id ?? this.id,
+        feature: feature ?? this.feature,
+        stateValue: stateValue ?? this.stateValue,
+        enabled: enabled ?? this.enabled,
+        environment: environment ?? this.environment,
+        identity: identity ?? this.identity,
+        featureSegment: featureSegment ?? this.featureSegment,
+      );
+}

--- a/lib/src/core/model/flag.g.dart
+++ b/lib/src/core/model/flag.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, non_constant_identifier_names, type_annotate_public_apis, omit_local_variable_types, unnecessary_this
+
+part of 'flag.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Flag _$FlagFromJson(Map<String, dynamic> json) => Flag(
+      id: (json['id'] as num?)?.toInt(),
+      feature: Feature.fromJson(json['feature'] as Map<String, dynamic>),
+      stateValue: stringFromJson(json['feature_state_value']),
+      enabled: json['enabled'] as bool?,
+      environment: (json['environment'] as num?)?.toInt(),
+      identity: (json['identity'] as num?)?.toInt(),
+      featureSegment: (json['feature_segment'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$FlagToJson(Flag instance) => <String, dynamic>{
+      'id': instance.id,
+      'feature': instance.feature.toJson(),
+      'feature_state_value': stringToJson(instance.stateValue),
+      'enabled': instance.enabled,
+      'environment': instance.environment,
+      'identity': instance.identity,
+      'feature_segment': instance.featureSegment,
+    };

--- a/lib/src/core/model/flags_and_traits.dart
+++ b/lib/src/core/model/flags_and_traits.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import 'package:json_annotation/json_annotation.dart';
+import 'index.dart';
+part 'flags_and_traits.g.dart';
+
+@JsonSerializable()
+class FlagsAndTraits {
+  final List<Flag>? flags;
+  final List<Trait>? traits;
+  FlagsAndTraits({
+    this.flags,
+    this.traits,
+  });
+  factory FlagsAndTraits.fromJson(Map<String, dynamic> json) =>
+      _$FlagsAndTraitsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FlagsAndTraitsToJson(this);
+  String asString() => jsonEncode(toJson());
+  FlagsAndTraits copyWith({
+    List<Flag>? flags,
+    List<Trait>? traits,
+  }) =>
+      FlagsAndTraits(
+        flags: flags ?? this.flags,
+        traits: traits ?? this.traits,
+      );
+}

--- a/lib/src/core/model/flags_and_traits.g.dart
+++ b/lib/src/core/model/flags_and_traits.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, non_constant_identifier_names, type_annotate_public_apis, omit_local_variable_types, unnecessary_this
+
+part of 'flags_and_traits.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FlagsAndTraits _$FlagsAndTraitsFromJson(Map<String, dynamic> json) =>
+    FlagsAndTraits(
+      flags: (json['flags'] as List<dynamic>?)
+          ?.map((e) => Flag.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      traits: (json['traits'] as List<dynamic>?)
+          ?.map((e) => Trait.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$FlagsAndTraitsToJson(FlagsAndTraits instance) =>
+    <String, dynamic>{
+      'flags': instance.flags?.map((e) => e.toJson()).toList(),
+      'traits': instance.traits?.map((e) => e.toJson()).toList(),
+    };

--- a/lib/src/core/model/identity.dart
+++ b/lib/src/core/model/identity.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:json_annotation/json_annotation.dart';
+part 'identity.g.dart';
+
+/// Personalized user
+@JsonSerializable()
+class Identity {
+  @JsonKey(includeIfNull: false)
+  final bool? transient;
+  final String identifier;
+
+  const Identity({
+    this.transient,
+    required this.identifier,
+  });
+
+  factory Identity.fromJson(Map<String, dynamic> json) =>
+      _$IdentityFromJson(json);
+
+  Map<String, dynamic> toJson() => _$IdentityToJson(this);
+  String asString() => jsonEncode(toJson());
+  Identity copyWith({String? identifier, bool? transient}) =>
+      Identity(identifier: identifier ?? this.identifier, transient: transient ?? this.transient);
+}

--- a/lib/src/core/model/identity.g.dart
+++ b/lib/src/core/model/identity.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, non_constant_identifier_names, type_annotate_public_apis, omit_local_variable_types, unnecessary_this
+
+part of 'identity.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Identity _$IdentityFromJson(Map<String, dynamic> json) => Identity(
+      transient: json['transient'] as bool?,
+      identifier: json['identifier'] as String,
+    );
+
+Map<String, dynamic> _$IdentityToJson(Identity instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('transient', instance.transient);
+  val['identifier'] = instance.identifier;
+  return val;
+}

--- a/lib/src/core/model/index.dart
+++ b/lib/src/core/model/index.dart
@@ -1,0 +1,8 @@
+library;
+
+export 'feature.dart';
+export 'identity.dart';
+export 'flag.dart';
+export 'flags_and_traits.dart';
+export 'trait.dart';
+export 'loading.dart';

--- a/lib/src/core/model/loading.dart
+++ b/lib/src/core/model/loading.dart
@@ -1,0 +1,1 @@
+enum FlagsmithLoading { loading, loaded }

--- a/lib/src/core/model/trait.dart
+++ b/lib/src/core/model/trait.dart
@@ -7,6 +7,7 @@ part 'trait.g.dart';
 
 @JsonSerializable()
 class Trait {
+  @JsonKey(includeIfNull: false)
   final int? id;
   @JsonKey(includeIfNull: false)
   final bool? transient;

--- a/lib/src/core/model/trait.dart
+++ b/lib/src/core/model/trait.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+
+import 'package:json_annotation/json_annotation.dart';
+
+import 'identity.dart';
+part 'trait.g.dart';
+
+@JsonSerializable()
+class Trait {
+  final int? id;
+  @JsonKey(includeIfNull: false)
+  final bool? transient;
+  @JsonKey(name: 'trait_key')
+  final String key;
+  @JsonKey(name: 'trait_value', fromJson: _fromJson, toJson: _toJson)
+  final dynamic value;
+
+  Trait({
+    this.id,
+    this.transient,
+    required this.key,
+    required this.value,
+  });
+
+  factory Trait.fromJson(Map<String, dynamic> json) => _$TraitFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TraitToJson(this);
+
+  String asString() => jsonEncode(toJson());
+
+  Trait copyWith({
+    int? id,
+    String? key,
+    dynamic value,
+  }) =>
+      Trait(
+        id: id ?? this.id,
+        key: key ?? this.key,
+        value: value ?? this.value,
+      );
+
+  static dynamic _fromJson(dynamic jsonValue) {
+    if (jsonValue is num) {
+      if (jsonValue % 1 == 0) {
+        return jsonValue.toInt(); // Treat as int if it's a whole number
+      } else {
+        return jsonValue.toDouble(); // Treat as double if it's a decimal
+      }
+    } else if (jsonValue is String || jsonValue is bool) {
+      return jsonValue;
+    }
+    throw ArgumentError('Invalid value type');
+  }
+
+  static dynamic _toJson(dynamic value) {
+    if (value is double || value is int || value is String || value is bool) {
+      return value;
+    }
+    throw ArgumentError('Invalid value type');
+  }
+}
+
+@JsonSerializable()
+class TraitWithIdentity {
+  final Identity identity;
+  @JsonKey(name: 'trait_key')
+  final String key;
+  @JsonKey(
+    name: 'trait_value',
+    fromJson: _fromJson,
+    toJson: _toJson,
+  )
+  final dynamic value;
+
+  TraitWithIdentity({
+    required this.identity,
+    required this.key,
+    required this.value,
+  });
+
+  factory TraitWithIdentity.fromJson(Map<String, dynamic> json) =>
+      _$TraitWithIdentityFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TraitWithIdentityToJson(this);
+
+  String asString() => jsonEncode(toJson());
+
+  TraitWithIdentity copyWith({
+    Identity? identity,
+    String? key,
+    dynamic value,
+  }) =>
+      TraitWithIdentity(
+        identity: identity ?? this.identity,
+        key: key ?? this.key,
+        value: value ?? this.value,
+      );
+
+  static dynamic _fromJson(dynamic jsonValue) {
+    if (jsonValue is num) {
+      if (jsonValue % 1 == 0) {
+        return jsonValue.toInt(); // Treat as int if it's a whole number
+      } else {
+        return jsonValue.toDouble(); // Treat as double if it's a decimal
+      }
+    } else if (jsonValue is String || jsonValue is bool) {
+      return jsonValue;
+    }
+    throw ArgumentError('Invalid value type');
+  }
+
+  static dynamic _toJson(dynamic value) {
+    if (value is double || value is int || value is String || value is bool) {
+      return value;
+    }
+    throw ArgumentError('Invalid value type');
+  }
+}

--- a/lib/src/core/model/trait.g.dart
+++ b/lib/src/core/model/trait.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: implicit_dynamic_parameter, non_constant_identifier_names, type_annotate_public_apis, omit_local_variable_types, unnecessary_this
+
+part of 'trait.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Trait _$TraitFromJson(Map<String, dynamic> json) => Trait(
+      id: (json['id'] as num?)?.toInt(),
+      transient: json['transient'] as bool?,
+      key: json['trait_key'] as String,
+      value: Trait._fromJson(json['trait_value']),
+    );
+
+Map<String, dynamic> _$TraitToJson(Trait instance) {
+  final val = <String, dynamic>{
+    'id': instance.id,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('transient', instance.transient);
+  val['trait_key'] = instance.key;
+  val['trait_value'] = Trait._toJson(instance.value);
+  return val;
+}
+
+TraitWithIdentity _$TraitWithIdentityFromJson(Map<String, dynamic> json) =>
+    TraitWithIdentity(
+      identity: Identity.fromJson(json['identity'] as Map<String, dynamic>),
+      key: json['trait_key'] as String,
+      value: TraitWithIdentity._fromJson(json['trait_value']),
+    );
+
+Map<String, dynamic> _$TraitWithIdentityToJson(TraitWithIdentity instance) =>
+    <String, dynamic>{
+      'identity': instance.identity.toJson(),
+      'trait_key': instance.key,
+      'trait_value': TraitWithIdentity._toJson(instance.value),
+    };

--- a/lib/src/core/model/trait.g.dart
+++ b/lib/src/core/model/trait.g.dart
@@ -16,9 +16,7 @@ Trait _$TraitFromJson(Map<String, dynamic> json) => Trait(
     );
 
 Map<String, dynamic> _$TraitToJson(Trait instance) {
-  final val = <String, dynamic>{
-    'id': instance.id,
-  };
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -26,6 +24,7 @@ Map<String, dynamic> _$TraitToJson(Trait instance) {
     }
   }
 
+  writeNotNull('id', instance.id);
   writeNotNull('transient', instance.transient);
   val['trait_key'] = instance.key;
   val['trait_value'] = Trait._toJson(instance.value);

--- a/lib/src/core/storage/in_memory_storage.dart
+++ b/lib/src/core/storage/in_memory_storage.dart
@@ -1,16 +1,16 @@
-import 'package:flagsmith/flagsmith.dart';
+import '../crud_storage.dart';
 
-/// CustomInMemoryStore storage
-class CustomInMemoryStore extends CoreStorage {
+/// InMemoryStore storage
+class InMemoryStorage extends CoreStorage {
   final Map<String, String> _items = <String, String>{};
 
-  CustomInMemoryStore() {
+  InMemoryStorage() {
     init();
   }
 
   @override
   Future<void> init() async {
-    return Future(() => null);
+    return Future.value(null);
   }
 
   /// Clear items

--- a/lib/src/core/storage_provider.dart
+++ b/lib/src/core/storage_provider.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:rxdart/rxdart.dart';
+
+import 'crud_storage.dart';
+import 'model/flag.dart';
+import 'tools/security.dart';
+
+class StorageProvider with SecureStorage {
+  Map<String, BehaviorSubject<Flag>?> _streams = {};
+  late StorageSecurity _storageSecurity;
+  final CoreStorage _storage;
+  final bool logEnabled;
+  void log(message) {
+    if (logEnabled) {
+      // ignore: avoid_print
+      print(message);
+    }
+  }
+
+  StorageProvider(this._storage, {String? password, this.logEnabled = false}) {
+    assert(password != null);
+    _storageSecurity = StorageSecurity(password);
+    _storage.init();
+    _initSubjects();
+  }
+
+  @override
+  Future<String?> getSecuredValue(String key) async {
+    var item = await _storage.read(key);
+    if (item == null) {
+      return null;
+    }
+    var decrypted = _storageSecurity.decrypt(item);
+    return decrypted;
+  }
+
+  @override
+  Future<bool> setSecuredValue(String key, String value,
+      {bool update = false}) async {
+    var encrypted = _storageSecurity.encrypt(value);
+    if (update) {
+      return await _storage.update(key, encrypted);
+    }
+    return await _storage.create(key, encrypted);
+  }
+
+  Future<bool> create(String key, Flag item) async {
+    var response = await setSecuredValue(key, item.asString());
+    _createSubject(await read(key));
+    return response;
+  }
+
+  Future<bool> delete(String key) {
+    _destroySubject(key);
+    _streams.remove(key);
+
+    return _storage.delete(key);
+  }
+
+  Future<Flag?> read(String key) async {
+    var decrypted = await getSecuredValue(key);
+    if (decrypted == null) {
+      return null;
+    }
+    return Flag.fromJson(jsonDecode(decrypted) as Map<String, dynamic>);
+  }
+
+  Future<bool> update(String key, Flag item) async {
+    var result = await setSecuredValue(key, item.asString(), update: true);
+    _updateSubject(await read(key));
+    return result;
+  }
+
+  Future<bool> clear() async {
+    _clearSubjects();
+    await _storage.clear();
+    return true;
+  }
+
+  Future<List<Flag>> getAll() async {
+    var list = await _storage.getAll();
+    return list.map((item) {
+      var decrypted = _storageSecurity.decrypt(item!)!;
+      return Flag.fromJson(jsonDecode(decrypted) as Map<String, dynamic>);
+    }).toList();
+  }
+
+  Future<bool> saveAll(List<Flag> items) async {
+    for (var item in items) {
+      final current = await read(item.key);
+      if (current != null) {
+        await update(item.key, item);
+      } else {
+        await create(item.key, item);
+      }
+    }
+    return true;
+  }
+
+  Future<bool> seed({required List<Flag> items}) async {
+    var list = items
+        .map((e) => MapEntry(e.key, _storageSecurity.encrypt(e.asString())))
+        .toList();
+    var result = await _storage.seed(list);
+    if (result) {
+      for (var item in items) {
+        _createSubject(item);
+      }
+    }
+    return result;
+  }
+
+  Stream<Flag>? stream(String featureName) => _streams[featureName]?.stream;
+
+  BehaviorSubject<Flag>? subject(String featureName) => _streams[featureName];
+
+  Future<void> _initSubjects() async {
+    var result = await getAll();
+    for (var flag in result) {
+      _createSubject(flag);
+    }
+  }
+
+  void _createSubject(Flag? item) {
+    if (item == null) {
+      return;
+    }
+
+    if (_streams[item.key] == null) {
+      _streams[item.key] = BehaviorSubject<Flag>.seeded(item);
+      log('_createSubject ${item.key} -> ${_streams[item.key]?.value}');
+    }
+  }
+
+  void _updateSubject(Flag? item) {
+    if (item == null) {
+      return;
+    }
+    _streams[item.key]?.add(item);
+    log('_updateSubject ${item.key} -> ${_streams[item.key]?.value.enabled} f: ${item.enabled}');
+  }
+
+  void _destroySubject(String featureName) {
+    try {
+      _streams[featureName]?.close();
+      _streams[featureName] = null;
+    } catch (e) {
+      log(e.toString());
+    }
+  }
+
+  void _clearSubjects() {
+    for (var item in _streams.entries) {
+      _destroySubject(item.key);
+    }
+    _streams = {};
+  }
+
+  Future<bool> togggleFeature(String featureName) async {
+    var value = await read(featureName);
+    if (value == null) {
+      return false;
+    }
+    var current = value.enabled!;
+    var updated = value.copyWith(enabled: !current);
+    return await update(featureName, updated);
+  }
+}

--- a/lib/src/core/storage_type.dart
+++ b/lib/src/core/storage_type.dart
@@ -1,0 +1,2 @@
+/// [StorageType] defining type of storage used by instance of [FlagsmithClient]
+enum StorageType { inMemory, custom }

--- a/lib/src/core/tools/security.dart
+++ b/lib/src/core/tools/security.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:encrypt/encrypt.dart';
+
+class StorageSecurity {
+  final _random = Random.secure();
+  final String? password;
+  late Uint8List _encryptedPassword;
+  late Encrypter _enc;
+  StorageSecurity(this.password) {
+    _encryptedPassword = _generateEncryptPassword(password!);
+    _enc = Encrypter(Salsa20(Key(_encryptedPassword)));
+  }
+  Uint8List _generateEncryptPassword(String password) {
+    var blob = Uint8List.fromList(md5.convert(utf8.encode(password)).bytes);
+    assert(blob.length == 16);
+    return blob;
+  }
+
+  Uint8List _randBytes(int length) {
+    return Uint8List.fromList(
+        List<int>.generate(length, (i) => _random.nextInt(256)));
+  }
+
+  String encrypt(String value) {
+    final iv = _randBytes(8);
+    final ivEncoded = base64.encode(iv);
+    assert(ivEncoded.length == 12);
+    final encoded = _enc.encrypt(json.encode(value), iv: IV(iv)).base64;
+    return '$ivEncoded$encoded';
+  }
+
+  String? decrypt(String value) {
+    assert(value.length >= 12);
+    final iv = base64.decode(value.substring(0, 12));
+
+    // Extract the real input
+    value = value.substring(12);
+
+    // Decode the input
+    return json.decode(_enc.decrypt64(value, iv: IV(iv))) as String?;
+  }
+}

--- a/lib/src/flagsmith_client.dart
+++ b/lib/src/flagsmith_client.dart
@@ -401,7 +401,7 @@ class FlagsmithClient {
       cachedUser = user;
       var identityData = user.toJson();
       if (traits != null && traits.isNotEmpty) {
-        identityData['traits'] = traits.map((t) => t.toJson());
+        identityData['traits'] = traits.map((t) => t.toJson()).toList();
       }
 
       var response = await _api.post(config.identitiesURI, data: identityData);

--- a/lib/src/storage/sharedpreferences_store.dart
+++ b/lib/src/storage/sharedpreferences_store.dart
@@ -1,0 +1,85 @@
+import '../core/core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FlagsmithSharedPreferenceStore extends CoreStorage {
+  SharedPreferences? _prefs;
+
+  FlagsmithSharedPreferenceStore() {
+    init();
+  }
+
+  Future<bool> containsKey(String key) async {
+    await init();
+    return Future<bool>.value(_prefs!.containsKey(key));
+  }
+
+  @override
+  Future<void> init() async {
+    _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  @override
+  Future<bool> clear() async {
+    await init();
+    return _prefs!.clear();
+  }
+
+  @override
+  Future<bool> create(String key, String item) async {
+    if (!await containsKey(key)) {
+      return await _prefs!.setString(key, item);
+    }
+    return false;
+  }
+
+  @override
+  Future<String?> read(String key) async {
+    if (await containsKey(key)) {
+      return _prefs!.getString(key);
+    }
+    return null;
+  }
+
+  @override
+  Future<bool> delete(String key) async {
+    if (await containsKey(key)) {
+      return await _prefs!.remove(key);
+    }
+    return false;
+  }
+
+  @override
+  Future<List<String>> getAll() async {
+    await init();
+    var items = <String>[];
+    var keys = _prefs!.getKeys();
+    for (var key in keys) {
+      var item = await read(key);
+      if (item != null) {
+        items.add(item);
+      }
+    }
+    return items;
+  }
+
+  @override
+  Future<bool> seed(List<MapEntry<String, String>>? items) async {
+    await init();
+    var saved = await getAll();
+    if (saved.isEmpty && items != null && items.isNotEmpty == true) {
+      for (var item in items) {
+        await create(item.key, item.value);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  Future<bool> update(String key, String item) async {
+    if (await containsKey(key)) {
+      return await _prefs!.setString(key, item);
+    }
+    return false;
+  }
+}

--- a/lib/src/storage/storage.dart
+++ b/lib/src/storage/storage.dart
@@ -1,0 +1,1 @@
+export 'sharedpreferences_store.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -62,6 +62,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.13"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.2"
   built_collection:
     dependency: transitive
     description:
@@ -86,6 +126,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   clock:
     dependency: transitive
     description:
@@ -237,6 +285,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   http:
     dependency: transitive
     description:
@@ -293,6 +349,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: ea1432d167339ea9b5bb153f0571d0039607a873d6e04e0117af043f14a1fd4b
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.8.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -477,6 +541,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   rxdart:
     dependency: "direct main"
     description:
@@ -586,6 +658,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      sha256: "6adebc0006c37dd63fe05bca0a929b99f06402fc95aa35bf36d67f5c06de01fd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.4"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -626,6 +706,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -674,6 +762,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.2"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,34 +5,39 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "72.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "6.7.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   asn1lib:
     dependency: transitive
     description:
       name: asn1lib
-      sha256: "21afe4333076c02877d14f4a89df111e658a6d466cbfc802eb705eb91bd5adfd"
+      sha256: "6b151826fcc95ff246cd219a0bf4c753ea14f4081ad71c61939becf3aba27f70"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.5"
   async:
     dependency: transitive
     description:
@@ -69,10 +74,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: ff627b645b28fb8bdb69e645f910c2458fd6b65f6585c3a53e0626024897dedf
+      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
       url: "https://pub.dev"
     source: hosted
-    version: "8.6.2"
+    version: "8.9.2"
   characters:
     dependency: transitive
     description:
@@ -93,18 +98,18 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "315a598c7fbe77f22de1c9da7cfd6fd21816312f16ffa124453b4fc679e540f1"
+      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
       url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "4.10.0"
   collection:
     dependency: "direct main"
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -117,50 +122,58 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      sha256: c1fb2dce3c0085f39dc72668e85f8e0210ec7de05345821ff58530567df345a5
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.3"
+    version: "1.9.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.3.7"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: ce75a1b40947fea0a0e16ce73337122a86762e38b982e1ccb909daa3b9bc4197
+      sha256: "5598aa796bbf4699afd5c67c0f5f6e2ed542afc956884b9cd58c306966efc260"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.2"
+    version: "5.7.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "33259a9276d6cea88774a0000cfae0d861003497755969c92faa223108620dc8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   encrypt:
     dependency: transitive
     description:
       name: encrypt
-      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
+      sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.3"
   file:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
@@ -186,18 +199,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_client_sse
-      sha256: "3c6ac3309b20c457374e373d32bbba2531c8724ddc2caad5737085d6edf25480"
+      sha256: "4ce0297206473dfc064b255fe086713240002e149f52519bd48c21423e4aa5d2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.3"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -210,18 +223,18 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: b9c29a161230ee03d3ccf545097fccd9b87a5264228c5d348202e0f0c28f9010
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.2.2"
   http_mock_adapter:
     dependency: "direct dev"
     description:
       name: http_mock_adapter
-      sha256: "00f48d69f31d79e389f7a8544b266a214020a8b79d9f376f54e84ae13d3e2965"
+      sha256: "46399c78bd4a0af071978edd8c502d7aeeed73b5fb9860bca86b5ed647a63c1b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.4"
+    version: "0.6.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -250,34 +263,34 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.1"
-  lcov_dart:
-    dependency: transitive
-    description:
-      name: lcov_dart
-      sha256: "69cc9dfcceb01245e1e35371e6d364242c20da896c7b8c44163cb2e7a6804014"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.0"
+    version: "4.9.0"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "5.0.0"
+  logger:
+    dependency: transitive
+    description:
+      name: logger
+      sha256: "697d067c60c20999686a0add96cf6aba723b3aa1f83ecf806a8097231529ec32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   logging:
     dependency: transitive
     description:
@@ -286,46 +299,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "7d5b53bcd556c1bc7ffbe4e4d5a19c3e112b7e925e9e172dd7c6ad0630812616"
+      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.2"
+    version: "5.4.4"
   node_preamble:
     dependency: transitive
     description:
@@ -346,18 +367,18 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      sha256: "4be0097fcf3fd3e8449e53730c631200ebc7b88016acecab2b0da2f0149222fe"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.3"
+    version: "3.9.1"
   pool:
     dependency: transitive
     description:
@@ -402,18 +423,18 @@ packages:
     dependency: transitive
     description:
       name: shelf_static
-      sha256: a41d3f53c4adf0f57480578c1d61d90342cd617de7fc8077b1304643c2d85c1e
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -423,18 +444,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   source_maps:
     dependency: transitive
     description:
@@ -455,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
@@ -471,10 +492,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -487,34 +508,34 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "9b0dd8e36af4a5b1569029949d50a52cb2a2a2fdaa20cebb96e6603b9ae241f9"
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.6"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "4bef837e56375537055fdbbbf6dd458b1859881f4c7e6da936158f77d61ab265"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.6"
+    version: "0.6.5"
   test_coverage_badge:
     dependency: "direct dev"
     description:
       name: test_coverage_badge
-      sha256: e12261ac174e18ceebf991a2c020329797dcf692e004d5b17f3a900b89063300
+      sha256: "3909beb9c06a40bd7bb74f23263eda0cfc1831055c3102f984790b8d45aa290c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.2"
   typed_data:
     dependency: transitive
     description:
@@ -535,10 +556,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: c538be99af830f478718b51630ec1b6bee5e74e52c8a802d328d9e71d35d2583
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "11.10.0"
+    version: "14.3.0"
   watcher:
     dependency: transitive
     description:
@@ -551,18 +572,26 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "1.1.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.1"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -580,5 +609,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.5.0 <4.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -26,10 +26,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.0"
   asn1lib:
     dependency: transitive
     description:
@@ -114,10 +114,10 @@ packages:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   coverage:
     dependency: transitive
     description:
@@ -127,13 +127,13 @@ packages:
     source: hosted
     version: "1.9.2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
-      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
+      sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.6"
   dart_style:
     dependency: transitive
     description:
@@ -159,13 +159,29 @@ packages:
     source: hosted
     version: "2.0.0"
   encrypt:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: encrypt
       sha256: "62d9aa4670cc2a8798bab89b39fc71b6dfbacf615de6cf5001fb39f7e4a996a2"
       url: "https://pub.dev"
     source: hosted
     version: "5.0.3"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
   file:
     dependency: transitive
     description:
@@ -178,20 +194,12 @@ packages:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
-  flagsmith_flutter_core:
-    dependency: "direct main"
-    description:
-      name: flagsmith_flutter_core
-      sha256: "4e025cb80c7dbc31fbc4f0789e0fde6dd7e779fe6da328322afccdabc87d510e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
+    version: "1.1.1"
   flutter:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -203,6 +211,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  flutter_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -268,13 +286,37 @@ packages:
     source: hosted
     version: "0.7.1"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.5"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: "direct dev"
     description:
@@ -371,6 +413,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pointycastle:
     dependency: transitive
     description:
@@ -399,10 +481,66 @@ packages:
     dependency: "direct main"
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
       url: "https://pub.dev"
     source: hosted
-    version: "0.27.7"
+    version: "0.28.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "07e050c7cd39bad516f8d64c455f04508d09df104be326d8c02551590a0d513d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: d2ca4132d3946fec2184261726b355836a82c33d7d5b67af32692aff18a4684e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -600,6 +738,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
@@ -610,4 +756,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.5.0 <4.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,3 +30,5 @@ dev_dependencies:
   http_mock_adapter: ^0.6.1
   mockito: ^5.4.2
   test_coverage_badge: ^0.3.2
+  build_runner: ^2.4.13
+  json_serializable: ^6.8.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   rxdart: ^0.27.7
 dev_dependencies:
   test: ^1.24.6
-  lints: ^1.0.1
-  http_mock_adapter: ^0.4.0
+  lints: ^5.0.0
+  http_mock_adapter: ^0.6.1
   mockito: ^5.4.2
-  test_coverage_badge: ^0.2.0
+  test_coverage_badge: ^0.3.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,22 +3,29 @@ description: >-
   Flutter Client SDK for https://www.flagsmith.com/, Flagsmith is 100% Open
   Source. Host yourself or let us take care of the hosting.
 
-version: 5.0.1
+version: 6.0.0
 homepage: https://github.com/Flagsmith/flagsmith-flutter-client
 repository: https://github.com/Flagsmith/flagsmith-flutter-client
 issue_tracker: https://github.com/Flagsmith/flagsmith-flutter-client/issues
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  flagsmith_flutter_core: ^3.0.0
+  flutter:
+    sdk: flutter
   flutter_client_sse: ^2.0.0
-  collection: ^1.17.0
+  collection: ^1.18.0
   dio: ^5.3.2
-  rxdart: ^0.27.7
+  rxdart: ^0.28.0
+  shared_preferences: ^2.3.2
+  json_annotation: ^4.9.0
+  encrypt: ^5.0.3
+  crypto: ^3.0.6
 dev_dependencies:
   test: ^1.24.6
+  flutter_test:
+    sdk: flutter
   lints: ^5.0.0
   http_mock_adapter: ^0.6.1
   mockito: ^5.4.2

--- a/test/core/flagsmith_core_test.dart
+++ b/test/core/flagsmith_core_test.dart
@@ -1,0 +1,97 @@
+import 'package:flagsmith/flagsmith.dart';
+import 'package:collection/collection.dart';
+import 'package:test/test.dart';
+
+import '../shared.dart';
+
+void main() {
+  final InMemoryStorage storage = InMemoryStorage();
+  late StorageProvider storageProvider;
+
+  setUpAll(() {
+    storageProvider =
+        StorageProvider(storage, password: 'pa5w0rD', logEnabled: true);
+  });
+
+  test('adds one to input values', () async {
+    final response = await storageProvider.seed(items: seeds);
+    expect(response, true);
+    final all = await storageProvider.getAll();
+    expect(all.length, seeds.length);
+  });
+  test('When update value', () async {
+    final response = await storageProvider.read(myFeatureName);
+    expect(response, isNotNull);
+    expect(response!.enabled, isTrue);
+  });
+  test('Update with enabled false', () async {
+    await storageProvider.update(
+        myFeatureName, Flag.seed(myFeatureName, enabled: false));
+    final responseUpdated = await storageProvider.read(myFeatureName);
+    expect(responseUpdated, isNotNull);
+    expect(responseUpdated!.enabled, isFalse);
+  });
+  test('Remove item from storage', () async {
+    await storageProvider.delete(myFeatureName);
+    final items = await storageProvider.getAll();
+    expect(items, isNotEmpty);
+    expect(items.length, seeds.length - 1);
+  });
+  test('Remove item from storage', () async {
+    await storageProvider.clear();
+    final items = await storageProvider.getAll();
+    expect(items, isEmpty);
+  });
+  test('Create a flag', () async {
+    final created = await storageProvider.create(
+        'test_feature', Flag.seed('test_feature', enabled: false));
+    expect(created, isTrue);
+  });
+  test('Save all flags', () async {
+    final created = await storageProvider.saveAll([
+      Flag.seed('test_feature_a', enabled: false),
+      Flag.seed('test_feature_b', enabled: true)
+    ]);
+    expect(created, isTrue);
+    final all = await storageProvider.getAll();
+    expect(all, isNotEmpty);
+    expect(
+        all,
+        const TypeMatcher<List<Flag>>().having(
+            (p0) => p0
+                .firstWhereOrNull((element) => element.key == 'test_feature_a'),
+            'saved flags containse feature flag `test_feature_a`',
+            isNotNull));
+  });
+
+  test('Update all flags', () async {
+    final created = await storageProvider.saveAll([
+      Flag.seed('test_feature_a', enabled: false),
+      Flag.seed('test_feature_b', enabled: true)
+    ]);
+    expect(created, isTrue);
+    final all = await storageProvider.getAll();
+    expect(all, isNotEmpty);
+    expect(
+        all,
+        const TypeMatcher<List<Flag>>().having(
+            (p0) => p0
+                .firstWhereOrNull((element) => element.key == 'test_feature_a'),
+            'saved flags containse feature flag `test_feature_a`',
+            isNotNull));
+  });
+
+  test('Init storage over', () async {
+    storageProvider =
+        StorageProvider(storage, password: 'pa5w0rD', logEnabled: true);
+    await storageProvider.clear();
+    expect(await storageProvider.seed(items: seeds), isTrue);
+    expect(await storageProvider.seed(items: seeds), isFalse);
+  });
+
+  test('Init storage missing passowrd', () {
+    expect(() {
+      StorageProvider(storage, password: null, logEnabled: true);
+    }, throwsA(isA<AssertionError>()));
+  });
+}

--- a/test/core/models/flag_test.dart
+++ b/test/core/models/flag_test.dart
@@ -1,0 +1,115 @@
+import 'package:flagsmith/flagsmith.dart';
+import 'dart:convert';
+import 'package:test/test.dart';
+
+import '../../shared.dart';
+
+void main() {
+  group('[Flag]', () {
+    late String testValue, featureValue;
+    setUp(() {
+      featureValue = r'''{
+        "id": 2,
+        "name": "font_size",
+        "created_date": "2018-06-04T12:51:18.646762Z",
+        "initial_value": 10,
+        "description": "test description",
+        "type": "STANDARD",
+        "project": 2
+      }''';
+      testValue = '''{
+      "id": 2,
+      "feature": {
+        "id": 2,
+        "name": "font_size",
+        "created_date": "2018-06-04T12:51:18.646762Z",
+        "initial_value": 10,
+        "description": "test description",
+        "type": "STANDARD",
+        "project": 2
+      },
+      "feature_state_value": "10.1.0",
+      "enabled": true,
+      "environment": 2,
+      "identity": 1
+    }
+    ''';
+    });
+    test('When flag is not empty, test values', () {
+      var flag = Flag.fromJson(jsonDecode(testValue) as Map<String, dynamic>);
+      expect(flag.stateValue, isNotNull);
+      expect(flag.enabled, true);
+      expect(flag.feature, isNotNull);
+      expect(flag.feature.name, isNotNull);
+      expect(flag.feature.description, isNotNull);
+    });
+    test('When feature successfuly parsed', () async {
+      final feature =
+          Feature.fromJson(jsonDecode(featureValue) as Map<String, dynamic>);
+      expect(feature, isNotNull);
+      expect(feature.id, 2);
+    });
+
+    test('When flag successfuly parsed', () {
+      var flag = Flag.fromJson(jsonDecode(testValue) as Map<String, dynamic>);
+      final flag0 = flag.asString();
+      expect(flag0, isA<String>());
+      expect(flag0, isNotNull);
+      expect(flag0, isNotEmpty);
+    });
+
+    test('When flag value successfuly updated', () {
+      var flag = Flag.fromJson(jsonDecode(testValue) as Map<String, dynamic>);
+      final feature = flag.feature.copyWith(initialValue: '12');
+      final flag0 = flag.copyWith(feature: feature);
+
+      expect(flag.feature.initialValue, '10');
+      expect(flag0.feature.initialValue, '12');
+      expect(flag.feature.initialValue, isNot(flag0.feature.initialValue));
+    });
+
+    test('When flag seed state is enabled', () {
+      var flagDefault = Flag.seed('feature');
+
+      expect(flagDefault.enabled, true);
+      expect(flagDefault.feature, isNotNull);
+
+      var flag = Flag.seed('feature');
+
+      expect(flag.enabled, true);
+      expect(flag.feature, isNotNull);
+    });
+    test('When flag seed state is disabled', () {
+      var flag = Flag.seed('feature', enabled: false);
+      expect(flag.enabled, false);
+      expect(flag.feature, isNotNull);
+    });
+    test('When flag seed type is cofig', () {
+      var flag = Flag.seed('feature', enabled: false, value: '1.0.0');
+      expect(flag.enabled, false);
+      expect(flag.feature, isNotNull);
+      expect(flag.stateValue, isNotNull);
+      expect(flag.stateValue, '1.0.0');
+    });
+  });
+
+  group('[FlagAndTraits]', () {
+    test('When response successfuly parsed', () {
+      final identity = FlagsAndTraits.fromJson(
+          jsonDecode(identitiesResponseData) as Map<String, dynamic>);
+      expect(identity.flags, isNotEmpty);
+      expect(identity.traits, isNotEmpty);
+
+      final converted = identity.toJson();
+      expect(converted, isNotNull);
+      expect(converted, isNotEmpty);
+
+      final copiedIdentity = identity.copyWith(flags: [], traits: []);
+      expect(
+          copiedIdentity,
+          const TypeMatcher<FlagsAndTraits>()
+              .having((e) => e.flags, 'flags are empty', isEmpty)
+              .having((e) => e.traits, 'traits are empty', isEmpty));
+    });
+  });
+}

--- a/test/core/models/future_test.dart
+++ b/test/core/models/future_test.dart
@@ -1,0 +1,18 @@
+import 'package:flagsmith/flagsmith.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('[Futures]', () {
+    test('When value is normalized then success', () {
+      var testValue = 'test String';
+      var normalized = testValue.normalize();
+      expect(normalized, 'test_string');
+    });
+
+    test('When value was not trimed, then normalize', () {
+      var testValue = ' _testStri ng';
+      var normalized = testValue.normalize();
+      expect(normalized, '_teststri_ng');
+    });
+  });
+}

--- a/test/core/models/identity_test.dart
+++ b/test/core/models/identity_test.dart
@@ -1,0 +1,46 @@
+import 'package:flagsmith/flagsmith.dart';
+import 'dart:convert';
+import 'package:test/test.dart';
+
+void main() {
+  const identityId = '123-456-789';
+  const identityJson = r'''{"identifier":"123-456-789"}''';
+  const transientIdentityJson =
+      r'''{"identifier":"123-456-789","transient":true}''';
+  final decodedIdentityJson = jsonDecode(identityJson) as Map<String, dynamic>;
+  final decodedTransientIdentityJson =
+      jsonDecode(transientIdentityJson) as Map<String, dynamic>;
+  // final malformedIdentityJson = '''{"identifier_bad_guy":"$identityId"}''';
+  group('[Identity]', () {
+    test('When identity response converted then success', () {
+      final identity = Identity.fromJson(decodedIdentityJson);
+      expect(identity.identifier, identityId);
+    });
+    test('When transient identity response converted then success', () {
+      final identity = Identity.fromJson(decodedTransientIdentityJson);
+      expect(identity.identifier, identityId);
+      expect(identity.transient, true);
+    });
+  });
+
+  group('[Identity] - copyWith', () {
+    test('When identity updated then success', () {
+      final identity = Identity.fromJson(decodedIdentityJson);
+      expect(identity.identifier, identityId);
+
+      final updated = identity.copyWith(identifier: 'newOne', transient: true);
+      expect(updated.identifier, 'newOne');
+      expect(updated.transient, true);
+      expect(identity.hashCode, isNot(updated.hashCode));
+    });
+    test('When identity not updated then success', () {
+      final identity = Identity.fromJson(decodedIdentityJson);
+      expect(identity.identifier, identityId);
+
+      final updated = identity.copyWith();
+
+      expect(identity.identifier, identityId);
+      expect(identity, isNot(updated));
+    });
+  });
+}

--- a/test/core/models/trait_identity_test.dart
+++ b/test/core/models/trait_identity_test.dart
@@ -1,0 +1,96 @@
+import 'package:flagsmith/flagsmith.dart';
+import 'dart:convert';
+import 'package:test/test.dart';
+
+void main() {
+  const identityId = '123-456-789';
+  const traitStringValue = '''{
+    "identity": {
+      "identifier": "$identityId"
+    },
+    "trait_key": "trait_key",
+    "trait_value": "value"
+  }''';
+  final decodedTraitStringValue =
+      jsonDecode(traitStringValue) as Map<String, dynamic>;
+  const traitNotStringValue = '''{
+    "identity": {
+      "identifier": "$identityId"
+    },
+    "trait_key": "trait_key",
+    "trait_value": true
+  }''';
+  final decodedTraitNotStringValue =
+      jsonDecode(traitNotStringValue) as Map<String, dynamic>;
+  group('[TraitWithIdentity] - basic tests', () {
+    test('When trait with identity parsed then success', () {
+      final trait = TraitWithIdentity.fromJson(decodedTraitStringValue);
+      expect(trait.identity.identifier, identityId);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+    });
+
+    test('When trait with identity parsed with non string, then success', () {
+      final trait = TraitWithIdentity.fromJson(decodedTraitNotStringValue);
+      expect(trait.identity.identifier, identityId);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, true);
+    });
+  });
+
+  group('[TraitWithIdentity] - converting', () {
+    test('When trait with identity converted, then success', () {
+      final trait = TraitWithIdentity.fromJson(decodedTraitStringValue);
+
+      expect(trait.identity.identifier, identityId);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+
+      final mapped = trait.asString();
+      expect(mapped, isNotNull);
+      expect(mapped.runtimeType, String);
+    });
+    test('When trait with identity converted to Map<String, dynamic>', () {
+      final trait = TraitWithIdentity.fromJson(decodedTraitStringValue);
+
+      expect(trait.identity.identifier, identityId);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+
+      final mapped = trait.toJson();
+      expect(mapped, isNotNull);
+      expect(mapped['identity']['identifier'], identityId);
+      expect(mapped['trait_key'], 'trait_key');
+      expect(mapped['trait_value'], 'value');
+    });
+  });
+  group('[TraitWithIdentity] - copyWith', () {
+    test('When trait with identity updated then success', () {
+      final trait = TraitWithIdentity.fromJson(decodedTraitStringValue);
+
+      expect(trait.identity.identifier, identityId);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+      final updated = trait.copyWith(
+          identity: const Identity(identifier: '13'),
+          key: 'trait_key2',
+          value: 'value2');
+
+      expect(updated.identity.identifier, '13');
+      expect(updated.key, 'trait_key2');
+      expect(updated.value, 'value2');
+    });
+    test('When trait with identity not updated then success', () {
+      final trait = TraitWithIdentity.fromJson(decodedTraitStringValue);
+
+      expect(trait.identity.identifier, identityId);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+      final updated = trait.copyWith();
+
+      expect(trait.identity.identifier, identityId);
+      expect(updated.key, 'trait_key');
+      expect(updated.value, 'value');
+    });
+  });
+}

--- a/test/core/models/trait_test.dart
+++ b/test/core/models/trait_test.dart
@@ -1,0 +1,222 @@
+import 'package:flagsmith/flagsmith.dart';
+import 'dart:convert';
+import 'package:test/test.dart';
+
+void main() {
+  const traitStringValue = '''{
+    "id": 12,
+    "trait_key": "trait_key",
+    "trait_value": "value"
+  }''';
+  final decodedTraitStringValue =
+      jsonDecode(traitStringValue) as Map<String, dynamic>;
+
+  const traitBoolValue = '''{
+    "id": 12,
+    "trait_key": "trait_key",
+    "trait_value": true
+  }''';
+  final decodedTraitBoolValue =
+      jsonDecode(traitBoolValue) as Map<String, dynamic>;
+  const traitIntValue = '''{
+    "id": 12,
+    "trait_key": "trait_key",
+    "trait_value": 1
+  }''';
+  final decodedTraitIntValue =
+      jsonDecode(traitIntValue) as Map<String, dynamic>;
+  const traitDoubleValue = '''{
+    "id": 12,
+    "trait_key": "trait_key",
+    "trait_value": 10.1
+  }''';
+  final decodedTraitDoubleValue =
+      jsonDecode(traitDoubleValue) as Map<String, dynamic>;
+  const transientTraitValue = '''{
+    "id": 12,
+    "trait_key": "trait_key",
+    "trait_value": "transient",
+    "transient": true
+  }''';
+  final decodedTransientTraitValue =
+      jsonDecode(transientTraitValue) as Map<String, dynamic>;
+
+  group('[Trait] - basic tests', () {
+    test('When trait parsed then success', () {
+      final trait = Trait.fromJson(decodedTraitStringValue);
+      expect(trait.id, 12);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+    });
+
+    test('When trait parsed with bool value then success', () {
+      final trait = Trait.fromJson(decodedTraitBoolValue);
+      expect(trait.id, 12);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, true);
+    });
+    test('When trait parsed with int value then success', () {
+      final trait = Trait.fromJson(decodedTraitIntValue);
+      expect(trait.id, 12);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 1);
+    });
+
+    test('When trait parsed with double value then success', () {
+      final trait = Trait.fromJson(decodedTransientTraitValue);
+      expect(trait.id, 12);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'transient');
+      expect(trait.transient, true);
+    });
+
+    test('When transient trait parsed then success', () {
+      final trait = Trait.fromJson(decodedTraitDoubleValue);
+      expect(trait.id, 12);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 10.1);
+    });
+  });
+
+  group('[Trait] - converting', () {
+    test('When trait parsed & converted then success', () {
+      final trait = Trait.fromJson(decodedTraitStringValue);
+
+      expect(trait.id, 12);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+
+      final mapped = trait.asString();
+      expect(mapped, isNotNull);
+      expect(mapped.runtimeType, String);
+    });
+    test('When trait converted to Map<String, dynamic> then success ', () {
+      final trait = Trait.fromJson(decodedTraitStringValue);
+
+      expect(trait.id, 12);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+
+      final mapped = trait.toJson();
+      expect(mapped, isNotNull);
+      expect(mapped['id'], 12);
+      expect(mapped['trait_key'], 'trait_key');
+      expect(mapped['trait_value'], 'value');
+    });
+  });
+  group('[Trait] - copyWith', () {
+    test('as a developer want to use with new data', () {
+      final trait = Trait.fromJson(decodedTraitStringValue);
+
+      expect(trait.id, 12);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+      final updated =
+          trait.copyWith(id: 13, key: 'trait_key2', value: 'value2');
+
+      expect(updated.id, 13);
+      expect(updated.key, 'trait_key2');
+      expect(updated.value, 'value2');
+    });
+    test('as a developer want to use copyWith same data', () {
+      final trait = Trait.fromJson(decodedTraitStringValue);
+
+      expect(trait.id, 12);
+      expect(trait.key, 'trait_key');
+      expect(trait.value, 'value');
+      final updated = trait.copyWith();
+
+      expect(updated.id, 12);
+      expect(updated.key, 'trait_key');
+      expect(updated.value, 'value');
+    });
+  });
+
+  group('toJson', () {
+    test(
+        'When trait with int value converted to Map<String, dynamic> then success',
+        () {
+      final trait = Trait(
+        id: 12,
+        key: 'trait_key',
+        value: 42,
+      );
+
+      final mapped = trait.toJson();
+
+      expect(mapped, isNotNull);
+      expect(mapped['id'], 12);
+      expect(mapped['trait_key'], 'trait_key');
+      expect(mapped['trait_value'], 42);
+    });
+
+    test(
+        'When trait with string value converted to Map<String, dynamic> then success',
+        () {
+      final trait = Trait(
+        id: 12,
+        key: 'trait_key',
+        value: 'trait_value',
+      );
+
+      final mapped = trait.toJson();
+
+      expect(mapped, isNotNull);
+      expect(mapped['id'], 12);
+      expect(mapped['trait_key'], 'trait_key');
+      expect(mapped['trait_value'], 'trait_value');
+    });
+
+    test(
+        'When trait with double value converted to Map<String, dynamic> then success',
+        () {
+      final trait = Trait(
+        id: 12,
+        key: 'trait_key',
+        value: 3.14,
+      );
+
+      final mapped = trait.toJson();
+
+      expect(mapped, isNotNull);
+      expect(mapped['id'], 12);
+      expect(mapped['trait_key'], 'trait_key');
+      expect(mapped['trait_value'], 3.14);
+    });
+
+    test(
+        'When trait with bool value converted to Map<String, dynamic> then success',
+        () {
+      final trait = Trait(
+        id: 12,
+        key: 'trait_key',
+        value: true,
+      );
+
+      final mapped = trait.toJson();
+
+      expect(mapped, isNotNull);
+      expect(mapped['id'], 12);
+      expect(mapped['trait_key'], 'trait_key');
+      expect(mapped['trait_value'], true);
+    });
+
+    test('When transient trait converted to Map<String, dynamic> then success',
+        () {
+      final trait = Trait(
+        id: 12,
+        key: 'trait_key',
+        value: 'transient',
+        transient: true,
+      );
+
+      final mapped = trait.toJson();
+
+      expect(mapped, isNotNull);
+      expect(mapped['id'], 12);
+      expect(mapped['trait_key'], 'trait_key');
+      expect(mapped['trait_value'], 'transient');
+      expect(mapped['transient'], true);
+    });
+  });
+}

--- a/test/fg/flagsmith_analytics_test.dart
+++ b/test/fg/flagsmith_analytics_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flagsmith/flagsmith.dart';
-import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:test/test.dart';
 
 import '../shared.dart';
@@ -10,13 +9,12 @@ import '../shared.dart';
 void main() {
   group('[Analytics] Settings', () {
     late FlagsmithClient fs;
-    late DioAdapter _adapter;
     setUp(() async {
       fs = setupSyncClientAdapter(StorageType.inMemory,
           caches: true, isDebug: true);
       setupAdapter(fs, cb: (config, adapter) {
-        _adapter = adapter;
-        _adapter.onPost(fs.config.analyticsURI, (server) {
+        adapter = adapter;
+        adapter.onPost(fs.config.analyticsURI, (server) {
           return server.reply(200, jsonDecode(analyticsData));
         }, data: jsonDecode(analyticsData));
       });
@@ -67,8 +65,8 @@ void main() {
       await fs.getFeatureFlagValue('my_feature');
       expect(fs.flagAnalytics.containsKey('my_feature'), isTrue);
       expect(fs.flagAnalytics['my_feature'], 2);
-      final _response = await fs.syncAnalyticsData();
-      expect(_response?.statusCode, 200);
+      final response = await fs.syncAnalyticsData();
+      expect(response?.statusCode, 200);
       expect(fs.flagAnalytics.isEmpty, isTrue);
     });
     test('When analytics was sent and failed, then current store is not empty',

--- a/test/fg/flagsmith_caches_test.dart
+++ b/test/fg/flagsmith_caches_test.dart
@@ -14,12 +14,12 @@ void main() {
       fs.close();
     });
     test('When caches not enabled then fail', () async {
-      expect(() => fs.hasCachedFeatureFlag(notImplmentedFeature),
+      expect(() => fs.hasCachedFeatureFlag(notImplementedFeatureName),
           throwsA(isA<FlagsmithConfigException>()));
     });
 
     test('When caches not enabled and get cached flag then fail', () async {
-      expect(() => fs.getCachedFeatureFlagValue(notImplmentedFeature),
+      expect(() => fs.getCachedFeatureFlagValue(notImplementedFeatureName),
           throwsA(isA<FlagsmithConfigException>()));
     });
   });
@@ -35,31 +35,31 @@ void main() {
     });
     test('When caches enabled then enabled', () async {
       await fs.getFeatureFlags();
-      final _value = fs.hasCachedFeatureFlag(notImplmentedFeature);
-      expect(_value, false);
+      final value = fs.hasCachedFeatureFlag(notImplementedFeatureName);
+      expect(value, false);
     });
 
     test('When caches enabled then get value', () async {
       await fs.getFeatureFlags();
-      final _value = fs.hasCachedFeatureFlag(notImplmentedFeature);
-      expect(_value, false);
+      final value = fs.hasCachedFeatureFlag(notImplementedFeatureName);
+      expect(value, false);
 
-      final _flagValue = fs.getCachedFeatureFlagValue('min_version');
-      expect(_flagValue, '2.0.0');
+      final flagValue = fs.getCachedFeatureFlagValue('min_version');
+      expect(flagValue, '2.0.0');
     });
 
     test('When feature flag remove then success', () async {
-      final _featureName = 'my_feature';
+      final featureName = 'my_feature';
       await fs.reset();
 
-      final _current = await fs.hasFeatureFlag(_featureName);
-      expect(_current, true);
+      final current = await fs.hasFeatureFlag(featureName);
+      expect(current, true);
 
-      var result = await fs.removeFeatureFlag(_featureName);
+      var result = await fs.removeFeatureFlag(featureName);
       expect(result, true);
 
-      final _removed = await fs.hasFeatureFlag(_featureName);
-      expect(_removed, false);
+      final removed = await fs.hasFeatureFlag(featureName);
+      expect(removed, false);
     });
 
     test('When cache is not empty', () async {

--- a/test/fg/flagsmith_exceptions_test.dart
+++ b/test/fg/flagsmith_exceptions_test.dart
@@ -40,21 +40,21 @@ void main() {
     test(
         'When exception with description raised, then we are able to read error description',
         () async {
-      final _description = 'generic error';
+      final description = 'generic error';
       expect(
-          () => Mocked().genericError(message: _description),
+          () => Mocked().genericError(message: description),
           throwsA(TypeMatcher<FlagsmithException>().having(
               (s) => s.toString(),
               'correct error description',
-              'FlagsmithException: $_description')));
+              'FlagsmithException: $description')));
     });
 
     test(
         'When exception without description raised, then we`ll see only type of exception',
         () async {
-      final String? _description = null;
+      final String? description = null;
       expect(
-          () => Mocked().genericError(message: _description),
+          () => Mocked().genericError(message: description),
           throwsA(TypeMatcher<FlagsmithException>().having((s) => s.toString(),
               'correct error description', 'FlagsmithException')));
     });
@@ -87,8 +87,8 @@ void main() {
           throwsA(isA<FlagsmithApiException>()));
     });
     test('When create trait return error', () async {
-      var _user = Identity(identifier: 'test_another_user');
-      final _data = TraitWithIdentity(identity: _user, key: 'age', value: '25');
+      var user = Identity(identifier: 'test_another_user');
+      final data = TraitWithIdentity(identity: user, key: 'age', value: '25');
       fs = setupSyncClientAdapter(StorageType.inMemory);
       await fs.initialize();
       setupAdapter(fs, cb: (config, adapter) {
@@ -100,10 +100,10 @@ void main() {
               error: Exception('404'),
             ),
           );
-        }, data: _data.toJson());
+        }, data: data.toJson());
       });
 
-      expect(() => fs.createTrait(value: _data),
+      expect(() => fs.createTrait(value: data),
           throwsA(isA<FlagsmithApiException>()));
     });
     test('When bulk update traits, then fail', () async {
@@ -118,23 +118,23 @@ void main() {
               error: Exception('404'),
             ),
           );
-        }, data: jsonDecode(bulkTraitUpdateResponse));
+        }, data: jsonDecode(identitiesRequestData));
       });
-      final _user = Identity(identifier: 'test_another_user');
-      final _data = [
+      final user = Identity(identifier: 'test_another_user');
+      final data = [
         TraitWithIdentity(
-          identity: _user,
+          identity: user,
           key: 'age',
           value: '21',
         ),
         TraitWithIdentity(
-          identity: _user,
+          identity: user,
           key: 'age2',
           value: '21',
         )
       ];
 
-      expect(() => fs.updateTraits(value: _data),
+      expect(() => fs.updateTraits(value: data),
           throwsA(isA<FlagsmithApiException>()));
     });
 
@@ -146,32 +146,32 @@ void main() {
           return server.reply(200, null);
         }, data: []);
       });
-      final _response = await fs.updateTraits(value: <TraitWithIdentity>[]);
-      expect(_response, isNull);
+      final response = await fs.updateTraits(value: <TraitWithIdentity>[]);
+      expect(response, isNull);
     });
 
     test('When fetch flags, but data are malformed, then fail', () async {
       fs = setupSyncClientAdapter(StorageType.inMemory);
-      final _flag =
-          Flag.named(feature: Feature.named(name: myFeature), enabled: false);
+      final flag = Flag.named(
+          feature: Feature.named(name: myFeatureName), enabled: false);
       setupEmptyAdapter(fs, cb: (config, adapter) {
-        adapter.onGet(config.flagsURI,
-            (server) => server.reply(200, jsonEncode([_flag])));
+        adapter.onGet(
+            config.flagsURI, (server) => server.reply(200, jsonEncode([flag])));
       });
 
       expect(() => fs.getFeatureFlags(), throwsA(isA<FlagsmithApiException>()));
     });
 
     test('When fetch user flags, but data are malformed, then fail', () async {
-      final _user = Identity(identifier: 'test_another_user');
-      final _data = [
+      final user = Identity(identifier: 'test_another_user');
+      final data = [
         TraitWithIdentity(
-          identity: _user,
+          identity: user,
           key: 'age',
           value: '21',
         ),
         TraitWithIdentity(
-          identity: _user,
+          identity: user,
           key: 'age2',
           value: '21',
         )
@@ -180,11 +180,11 @@ void main() {
       fs = setupSyncClientAdapter(StorageType.inMemory);
       setupEmptyAdapter(fs, cb: (config, adapter) {
         adapter.onGet(config.identitiesURI,
-            (server) => server.reply(200, jsonDecode(jsonEncode([_data]))),
-            queryParameters: _user.toJson());
+            (server) => server.reply(200, jsonDecode(jsonEncode([data]))),
+            queryParameters: user.toJson());
       });
 
-      expect(() => fs.getFeatureFlags(user: _user),
+      expect(() => fs.getFeatureFlags(user: user),
           throwsA(isA<FlagsmithApiException>()));
     });
   });

--- a/test/fg/flagsmith_init_test.dart
+++ b/test/fg/flagsmith_init_test.dart
@@ -17,13 +17,13 @@ void main() {
       fs.close();
     });
     test('When caches not enabled then fail', () async {
-      expect(() => fs.hasCachedFeatureFlag(notImplmentedFeature),
+      expect(() => fs.hasCachedFeatureFlag(notImplementedFeatureName),
           throwsA(isA<FlagsmithConfigException>()));
     });
   });
   group('[Init] streams', () {
-    final _flag =
-        Flag.named(feature: Feature.named(name: myFeature), enabled: false);
+    final flag =
+        Flag.named(feature: Feature.named(name: myFeatureName), enabled: false);
 
     setUp(() async {
       fs = setupSyncClientAdapter(
@@ -31,7 +31,7 @@ void main() {
         isDebug: true,
       );
       setupEmptyAdapter(fs, cb: (config, adapter) {
-        adapter.onGet(config.flagsURI, (server) => server.reply(200, [_flag]));
+        adapter.onGet(config.flagsURI, (server) => server.reply(200, [flag]));
       });
       await fs.initialize();
     });
@@ -39,10 +39,10 @@ void main() {
       fs.close();
     });
     test('When change flag value, stream is updated', () async {
-      final _updated = _flag.copyWith(enabled: true);
-      expect(fs.stream(myFeature), emitsInOrder(<Flag>[_flag, _updated]));
+      final updated = flag.copyWith(enabled: true);
+      expect(fs.stream(myFeatureName), emitsInOrder(<Flag>[flag, updated]));
       await fs.getFeatureFlags(reload: true);
-      await fs.testToggle(myFeature);
+      await fs.testToggle(myFeatureName);
     });
   }, skip: true);
 }

--- a/test/fg/flagsmith_realtime_test.dart
+++ b/test/fg/flagsmith_realtime_test.dart
@@ -1,6 +1,5 @@
 import 'package:flagsmith/flagsmith.dart';
 import 'package:flutter_client_sse/flutter_client_sse.dart';
-import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:test/test.dart';
 
 import '../shared.dart';
@@ -10,13 +9,12 @@ const userIdentifier = 'test__user';
 void main() {
   group('[Realtime updates]', () {
     late FlagsmithClient fs;
-    late DioAdapter _adapter;
 
     setUp(() async {
       fs = setupSyncClientAdapter(StorageType.inMemory);
       setupAdapter(fs, cb: (config, adapter) {
-        _adapter = adapter;
-        _adapter.onGet(fs.config.identitiesURI, (server) {
+        adapter = adapter;
+        adapter.onGet(fs.config.identitiesURI, (server) {
           return server.reply(200, null);
         }, queryParameters: <String, dynamic>{
           'identifier': userIdentifier,

--- a/test/fg/flagsmith_traits_test.dart
+++ b/test/fg/flagsmith_traits_test.dart
@@ -2,21 +2,19 @@ import 'dart:convert';
 
 import 'package:flagsmith/flagsmith.dart';
 import 'package:test/test.dart';
-import 'package:http_mock_adapter/http_mock_adapter.dart';
 
 import '../shared.dart';
 
 void main() {
   group('[Flag manipulation]', () {
     late FlagsmithClient fs;
-    late DioAdapter _adapter;
     setUp(() async {
       fs = setupSyncClientAdapter(StorageType.inMemory);
       setupAdapter(fs, cb: (config, adapter) {
-        _adapter = adapter;
-        _adapter
+        adapter = adapter;
+        adapter
           ..onGet(fs.config.identitiesURI, (server) {
-            return server.reply(200, jsonDecode(fakeIdentitiesResponse));
+            return server.reply(200, jsonDecode(identitiesResponseData));
           }, queryParameters: <String, dynamic>{
             'identifier': 'test_another_user'
           })
@@ -26,8 +24,8 @@ void main() {
             'identifier': 'invalid_users_another_user'
           })
           ..onPost(fs.config.identitiesURI, (server) {
-            return server.reply(200, jsonDecode(bulkTraitUpdateResponse));
-          }, data: jsonDecode(bulkTraitUpdateResponse))
+            return server.reply(200, jsonDecode(identitiesResponseData));
+          }, data: jsonDecode(identitiesResponseData))
           ..onPost(fs.config.traitsURI, (server) {
             return server.reply(200, jsonDecode(traitAge25));
           }, data: jsonDecode(traitAge25));
@@ -50,18 +48,18 @@ void main() {
     });
     test('When localy change state of flag, then success', () async {
       await fs.getFeatureFlags();
-      expect(await fs.isFeatureFlagEnabled(myFeature), true);
-      await fs.testToggle(myFeature);
-      expect(await fs.isFeatureFlagEnabled(myFeature), false);
+      expect(await fs.isFeatureFlagEnabled(myFeatureName), true);
+      await fs.testToggle(myFeatureName);
+      expect(await fs.isFeatureFlagEnabled(myFeatureName), false);
     });
 
     test('When change state of flag, then cache success', () async {
       fs = setupSyncClientAdapter(StorageType.inMemory, caches: true);
       setupAdapter(fs, cb: (config, adapter) {});
       await fs.getFeatureFlags();
-      expect(await fs.isFeatureFlagEnabled(myFeature), true);
-      await fs.testToggle(myFeature);
-      expect(await fs.isFeatureFlagEnabled(myFeature), false);
+      expect(await fs.isFeatureFlagEnabled(myFeatureName), true);
+      await fs.testToggle(myFeatureName);
+      expect(await fs.isFeatureFlagEnabled(myFeatureName), false);
     });
   });
 
@@ -72,7 +70,7 @@ void main() {
       setupAdapter(fs, cb: (config, adapter) {
         adapter
           ..onGet(fs.config.identitiesURI, (server) {
-            return server.reply(200, jsonDecode(fakeIdentitiesResponse));
+            return server.reply(200, jsonDecode(identitiesResponseData));
           }, queryParameters: <String, dynamic>{
             'identifier': 'test_another_user'
           })
@@ -82,8 +80,8 @@ void main() {
             'identifier': 'invalid_users_another_user'
           })
           ..onPost(fs.config.identitiesURI, (server) {
-            return server.reply(200, jsonDecode(bulkTraitUpdateResponse));
-          }, data: jsonDecode(bulkTraitUpdateResponse))
+            return server.reply(200, jsonDecode(identitiesResponseData));
+          }, data: jsonDecode(identitiesRequestData))
           ..onPost(fs.config.traitsURI, (server) {
             return server.reply(200, jsonDecode(traitAge25));
           }, data: jsonDecode(traitAge25));
@@ -193,7 +191,7 @@ void main() {
       setupAdapter(fs, cb: (config, adapter) {
         adapter
           ..onGet(fs.config.identitiesURI, (server) {
-            return server.reply(200, jsonDecode(fakeIdentitiesResponse));
+            return server.reply(200, jsonDecode(identitiesResponseData));
           }, queryParameters: <String, dynamic>{
             'identifier': 'test_another_user'
           })
@@ -203,8 +201,8 @@ void main() {
             'identifier': 'invalid_users_another_user'
           })
           ..onPost(fs.config.identitiesURI, (server) {
-            return server.reply(200, jsonDecode(bulkTraitUpdateResponse));
-          }, data: jsonDecode(bulkTraitUpdateResponse))
+            return server.reply(200, jsonDecode(identitiesResponseData));
+          }, data: jsonDecode(identitiesResponseData)) // request
           ..onPost(fs.config.traitsURI, (server) {
             return server.reply(200, jsonDecode(traitAge25));
           }, data: jsonDecode(traitAge25));
@@ -241,17 +239,17 @@ void main() {
     });
 
     test('When create trait return data null', () async {
-      var _user = Identity(identifier: 'test_another_user');
-      final _data = TraitWithIdentity(identity: _user, key: 'age', value: '25');
+      var user = Identity(identifier: 'test_another_user');
+      final data = TraitWithIdentity(identity: user, key: 'age', value: '25');
       fs = setupSyncClientAdapter(StorageType.inMemory);
       await fs.initialize();
       setupAdapter(fs, cb: (config, adapter) {
         adapter.onPost(fs.config.traitsURI, (server) {
           return server.reply(200, null);
-        }, data: _data.toJson());
+        }, data: data.toJson());
       });
-      final _result = await fs.createTrait(value: _data);
-      expect(_result, isNull);
+      final result0 = await fs.createTrait(value: data);
+      expect(result0, isNull);
     });
   });
 }

--- a/test/fg/flagsmith_traits_test.dart
+++ b/test/fg/flagsmith_traits_test.dart
@@ -248,8 +248,38 @@ void main() {
           return server.reply(200, null);
         }, data: data.toJson());
       });
-      final result0 = await fs.createTrait(value: data);
-      expect(result0, isNull);
+      final result = await fs.createTrait(value: data);
+      expect(result, isNull);
+    });
+
+    test('When get flags with traits request expected', () async {
+      var user = Identity(identifier: 'test_another_user');
+      var traits = [
+        Trait(key: 'transient_trait', value: 'value', transient: true),
+        Trait(key: 'normal_trait', value: 'value'),
+      ];
+      fs = await setupClientAdapter(StorageType.inMemory);
+      setupEmptyAdapter(fs, cb: (config, adapter) {
+        adapter.onPost(fs.config.identitiesURI, (server) {
+          return server.reply(200, jsonDecode(identitiesResponseData));
+        }, data: jsonDecode(identitiesRequestWithTransientTraitData));
+      });
+      final result = await fs.getFeatureFlags(user: user, traits: traits);
+      expect(result, isNotNull);
+      expect(result, isNotEmpty);
+    });
+
+    test('When get flags for transient identity request expected', () async {
+      var user = Identity(identifier: 'test_another_user', transient: true);
+      fs = await setupClientAdapter(StorageType.inMemory);
+      setupEmptyAdapter(fs, cb: (config, adapter) {
+        adapter.onPost(fs.config.identitiesURI, (server) {
+          return server.reply(200, jsonDecode(identitiesResponseData));
+        }, data: user.toJson());
+      });
+      final result = await fs.getFeatureFlags(user: user);
+      expect(result, isNotNull);
+      expect(result, isNotEmpty);
     });
   });
 }

--- a/test/shared.dart
+++ b/test/shared.dart
@@ -724,6 +724,21 @@ final identitiesRequestData = '''{
     ]
 }''';
 
+final identitiesRequestWithTransientTraitData = '''{
+    "identifier": "test_another_user",
+    "traits": [
+      {
+        "transient": true,
+        "trait_key": "transient_trait",
+        "trait_value": "value"
+      },
+      {
+        "trait_key": "normal_trait",
+        "trait_value": "value"
+      }
+    ]
+}''';
+
 final createTraitRequestData = '''{
   "identifier": "test_another_user"
   "flags":[

--- a/test/shared.dart
+++ b/test/shared.dart
@@ -31,9 +31,10 @@ final seeds = [
   Flag.seed('enabled_feature', enabled: true),
   Flag.seed('enabled_value', enabled: true, value: '2.0.0')
 ];
-const notImplmentedFeature = 'not_implemented_flag';
-const myFeature = 'my_feature';
-final fakeMallformedResponse = r'''[
+final notImplementedFeatureName = 'not_implemented_flag';
+final myFeatureName = 'my_feature';
+
+final malformedResponseData = r'''[
     {
         "id": 48540,
         "feature": {
@@ -52,7 +53,8 @@ final fakeMallformedResponse = r'''[
         "feature_segment": null,
     },
 ]''';
-final fakeResponse = r'''[
+
+final flagsResponseData = r'''[
     {
         "id": 48540,
         "feature": {
@@ -531,7 +533,8 @@ final fakeResponse = r'''[
         "feature_segment": null
     }
 ]''';
-final fakeIdentitiesResponse = r'''{
+
+final identitiesResponseData = r'''{
     "flags": [
         {
           "id": 48540,
@@ -682,7 +685,24 @@ final fakeIdentitiesResponse = r'''{
     ]
 }''';
 
-final bulkTraitUpdateResponse = '''{
+final bulkTraitUpdateResponseData = '''[
+  {
+      "identity": {
+          "identifier": "test_another_user"
+      },
+      "trait_key": "age",
+      "trait_value": "21"
+  },
+  {
+    "identity": {
+        "identifier": "test_another_user"
+    },
+    "trait_key": "age2",
+    "trait_value": "21"
+  }
+]''';
+
+final identitiesRequestData = '''{
     "identifier": "test_another_user",
     "traits": [
       {
@@ -704,7 +724,7 @@ final bulkTraitUpdateResponse = '''{
     ]
 }''';
 
-final createTraitRequest = '''{
+final createTraitRequestData = '''{
   "identifier": "test_another_user"
   "flags":[
     {
@@ -777,10 +797,10 @@ void setupAdapter(FlagsmithClient fs,
   final config = fs.config;
 
   final dioAdapter = DioAdapter(dio: fs.client);
-  dioAdapter.onGet(
-      config.flagsURI, (server) => server.reply(200, jsonDecode(fakeResponse)));
-  dioAdapter.onGet(config.identitiesURI,
-      (server) => server.reply(200, jsonDecode(fakeIdentitiesResponse)));
+  dioAdapter.onGet(config.flagsURI,
+      (server) => server.reply(200, jsonDecode(flagsResponseData)));
+  dioAdapter.onPost(config.identitiesURI,
+      (server) => server.reply(200, jsonDecode(identitiesResponseData)));
 
   if (cb != null) {
     cb(config, dioAdapter);

--- a/test/storage/storage_test.dart
+++ b/test/storage/storage_test.dart
@@ -1,0 +1,100 @@
+import 'package:flagsmith/flagsmith.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../shared.dart';
+
+void main() {
+  SharedPreferences.setMockInitialValues(<String, String>{});
+
+  final CoreStorage storage = FlagsmithSharedPreferenceStore();
+  late StorageProvider storageProvider;
+
+  setUpAll(() {
+    storageProvider =
+        StorageProvider(storage, password: 'pa5w0rD', logEnabled: true);
+  });
+
+  test('adds one to input values', () async {
+    final response = await storageProvider.seed(items: seeds);
+    expect(response, true);
+    final all = await storageProvider.getAll();
+    expect(all.length, seeds.length);
+  });
+  test('When update value', () async {
+    final response = await storageProvider.read(myFeatureName);
+    expect(response, isNotNull);
+    expect(response!.enabled, isTrue);
+  });
+  test('Update with enabled false', () async {
+    await storageProvider.update(
+        myFeatureName, Flag.seed(myFeatureName, enabled: false));
+    final responseUpdated = await storageProvider.read(myFeatureName);
+    expect(responseUpdated, isNotNull);
+    expect(responseUpdated!.enabled, isFalse);
+  });
+  test('Remove item from storage', () async {
+    await storageProvider.delete(myFeatureName);
+    final items = await storageProvider.getAll();
+    expect(items, isNotEmpty);
+    expect(items.length, seeds.length - 1);
+  });
+  test('Remove item from storage', () async {
+    await storageProvider.clear();
+    final items = await storageProvider.getAll();
+    expect(items, isEmpty);
+  });
+  test('Create a flag', () async {
+    final created = await storageProvider.create(
+        'test_feature', Flag.seed('test_feature', enabled: false));
+    expect(created, isTrue);
+  });
+  test('Save all flags', () async {
+    final created = await storageProvider.saveAll([
+      Flag.seed('test_feature_a', enabled: false),
+      Flag.seed('test_feature_b', enabled: true)
+    ]);
+    expect(created, isTrue);
+    final all0 = await storageProvider.getAll();
+    expect(all0, isNotEmpty);
+    expect(
+        all0,
+        const TypeMatcher<List<Flag>>().having(
+            (p0) => p0
+                .firstWhereOrNull((element) => element.key == 'test_feature_a'),
+            'saved flags containse feature flag `test_feature_a`',
+            isNotNull));
+  });
+
+  test('Update all flags', () async {
+    final created = await storageProvider.saveAll([
+      Flag.seed('test_feature_a', enabled: false),
+      Flag.seed('test_feature_b', enabled: true)
+    ]);
+    expect(created, isTrue);
+    final all0 = await storageProvider.getAll();
+    expect(all0, isNotEmpty);
+    expect(
+        all0,
+        const TypeMatcher<List<Flag>>().having(
+            (p0) => p0
+                .firstWhereOrNull((element) => element.key == 'test_feature_a'),
+            'saved flags containse feature flag `test_feature_a`',
+            isNotNull));
+  });
+
+  test('Init storage over', () async {
+    storageProvider =
+        StorageProvider(storage, password: 'pa5w0rD', logEnabled: true);
+    await storageProvider.clear();
+    expect(await storageProvider.seed(items: seeds), isTrue);
+    expect(await storageProvider.seed(items: seeds), isFalse);
+  });
+
+  test('Init storage missing passowrd', () {
+    expect(() {
+      StorageProvider(storage, password: null, logEnabled: true);
+    }, throwsA(isA<AssertionError>()));
+  });
+}


### PR DESCRIPTION
Closes #62.

Bumps package version to 6.0.0 due to a breaking change (dropping Flutter 2 support).

- Drop Flutter 2 support
- Publish via official Dart OIDC-enabled workflow
- Support transient identities and traits
- Integrate `flagsmith_core` and `flagsmith_storage_sharedpreferences`
- Minor unit test improvements
