### PR TITLE
refactor: Improve local cache speed

### DIFF
--- a/lib/src/flagsmith_client.dart
+++ b/lib/src/flagsmith_client.dart
@@ -578,11 +578,10 @@ class FlagsmithClient {
   ///
   Future<bool> testToggle(String featureName) async {
     final result = await storageProvider.togggleFeature(featureName);
-    final value = await storageProvider.read(featureName);
     if (config.caches) {
-      _flags.removeWhere((key, _) => key == featureName);
+      final value = await storageProvider.read(featureName);
       if (value != null) {
-        _flags[value.feature.name] = value;
+        _flags[featureName] = value;
       }
     }
     return result;

--- a/lib/src/flagsmith_client.dart
+++ b/lib/src/flagsmith_client.dart
@@ -356,7 +356,7 @@ class FlagsmithClient {
   Future<bool> removeFeatureFlag(String featureName) async {
     var result = await storageProvider.delete(featureName);
     if (config.caches) {
-      _flags.removeWhere((key, _) => key == featureName);
+      _flags.remove(featureName);
     }
     return result;
   }

--- a/lib/src/flagsmith_client.dart
+++ b/lib/src/flagsmith_client.dart
@@ -541,14 +541,8 @@ class FlagsmithClient {
     if (!config.caches) {
       return;
     }
-    final newData = <String, Flag>{};
-    for (var element in list) {
-      newData[element.feature.name] = element;
-    }
-
-    _flags
-      ..clear()
-      ..addAll(newData);
+    _flags.clear();
+    _flags.addEntries(list.map((flag) => MapEntry(flag.feature.name, flag)));
   }
 
   /// clear all data from storage

--- a/test/fg/flagsmith_caches_test.dart
+++ b/test/fg/flagsmith_caches_test.dart
@@ -57,6 +57,7 @@ void main() {
 
       var result = await fs.removeFeatureFlag(featureName);
       expect(result, true);
+      expect(fs.cachedFlags.containsKey(featureName), false);
 
       final removed = await fs.hasFeatureFlag(featureName);
       expect(removed, false);


### PR DESCRIPTION
Hi.

I realised that the cached uses quite a number of `firstWhereOrNull` for lookup. This PR changes to use Map so that getting flag value will be in O(1). I am currently thinking of using this but would also like some opinion from original maintainer on this idea :)

<details>
 <summary> Unit test result </summary>

```
~/flagsmith-flutter-client git:[main]
git reset --soft HEAD~1
~/flagsmith-flutter-client git:[main]
git push -f
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 10 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 767 bytes | 767.00 KiB/s, done.
Total 5 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To github.com:yuzurihaaa/flagsmith-flutter-client.git
 + b792203...139d338 main -> main (forced update)
~/flagsmith-flutter-client git:[main]
git reset --soft HEAD~1
~/flagsmith-flutter-client git:[main]
git push -f
Enumerating objects: 9, done.
Counting objects: 100% (9/9), done.
Delta compression using up to 10 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 765 bytes | 765.00 KiB/s, done.
Total 5 (delta 3), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.
To github.com:yuzurihaaa/flagsmith-flutter-client.git
 + 139d338...9e9c928 main -> main (forced update)
~/flagsmith-flutter-client git:[main]
flutter test
00:02 +34: (REDACTED)/flagsmith-flutter-client/test/core/storage_reactive_test.dart: [Streams] Stream successfuly changed when flag was updated                   
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
_updateSubject my_feature -> false f: false
00:02 +35: (REDACTED)/flagsmith-flutter-client/test/core/storage_reactive_test.dart: [Streams] Subject value changed when flag was changed.                       
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
00:03 +36: (REDACTED)/flagsmith-flutter-client/test/core/flagsmith_core_test.dart: adds one to input values                                                       
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
00:03 +38: (REDACTED)/flagsmith-flutter-client/test/core/flagsmith_core_test.dart: Update with enabled false                                                      
_updateSubject my_feature -> false f: false
00:03 +41: (REDACTED)/flagsmith-flutter-client/test/core/flagsmith_core_test.dart: Create a flag                                                                  
_createSubject test_feature -> F(test_feature:false)
00:03 +42: (REDACTED)/flagsmith-flutter-client/test/core/flagsmith_core_test.dart: Save all flags                                                                 
_createSubject test_feature_a -> F(test_feature_a:false)
_createSubject test_feature_b -> F(test_feature_b:true)
00:03 +42: (REDACTED)/flagsmith-flutter-client/test/storage/storage_test.dart: adds one to input values                                                           
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
00:03 +44: (REDACTED)/flagsmith-flutter-client/test/core/flagsmith_core_test.dart: Update all flags                                                               
_updateSubject test_feature_a -> false f: false
00:03 +44: (REDACTED)/flagsmith-flutter-client/test/core/flagsmith_core_test.dart: Update all flags                                                               
_updateSubject test_feature_b -> true f: true
00:03 +45: (REDACTED)/flagsmith-flutter-client/test/core/flagsmith_core_test.dart: Init storage over                                                              
_createSubject test_feature -> F(test_feature:false)
_createSubject test_feature_a -> F(test_feature_a:false)
_createSubject test_feature_b -> F(test_feature_b:true)
00:03 +46: (REDACTED)/flagsmith-flutter-client/test/core/flagsmith_core_test.dart: Init storage over                                                              
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
00:03 +47: (REDACTED)/flagsmith-flutter-client/test/storage/storage_test.dart: Update with enabled false                                                          
_updateSubject my_feature -> false f: false
00:03 +51: (REDACTED)/flagsmith-flutter-client/test/storage/storage_test.dart: Create a flag                                                                      
_createSubject test_feature -> F(test_feature:false)
00:03 +52: (REDACTED)/flagsmith-flutter-client/test/storage/storage_test.dart: Save all flags                                                                     
_createSubject test_feature_a -> F(test_feature_a:false)
_createSubject test_feature_b -> F(test_feature_b:true)
00:03 +53: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_config_test.dart: [Config] When debug is enabled, then we should have LogInterceptor inside client
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
00:03 +53: (REDACTED)/flagsmith-flutter-client/test/storage/storage_test.dart: Update all flags                                                                   
_updateSubject test_feature_a -> false f: false
_updateSubject test_feature_b -> true f: true
00:03 +54: (REDACTED)/flagsmith-flutter-client/test/storage/storage_test.dart: Init storage over                                                                  
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
00:03 +58: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_config_test.dart: [External config] When self signed cert is enabled, then adapter is SelfSigned type
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
00:03 +60: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_config_test.dart: [Standard config] When self signed cert is disabled, then adapter is not SelfSigned type
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
00:05 +91 ~1: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_analytics_test.dart: [Analytics] Settings When starts client analytics are enabled as default 
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
*** Request ***
uri: https://offline.net/flags/
method: GET
responseType: ResponseType.json
followRedirects: true
persistentConnection: true
connectTimeout: 0:00:10.000000
sendTimeout: 0:00:20.000000
receiveTimeout: 0:00:20.000000
receiveDataWhenStatusError: true
extra: {}
headers:
 X-Environment-Key: CoJErJUXmihfMDVwTzBff4_fake
 Accept: application/json
data:
null

00:05 +99 ~1: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_analytics_test.dart: [Analytics] Settings When starts client analytics are enabled as default 
*** Response ***
uri: https://offline.net/flags/
statusCode: 200
headers:
 content-type: application/json
Response Text:
[{id: 48540, feature: {id: 9368, name: fake_disabled_feature, created_date: 2021-05-24T08:38:29.203517Z, description: Fake Disabled feature, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 48541, feature: {id: 9368, name: disabled_feature, created_date: 2021-05-24T08:38:29.203517Z, description: Disabled feature, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 48543, feature: {id: 9369, name: enabled_feature, created_date: 2021-05-24T08:38:47.375641Z, description: Enabled test feature, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 7822, identity: null, feature_segment: null}, {id: 48545, feature: {id: 9370, name: min_version, created_date: 2021-05-24T08:39:05.095219Z, description: test min version, initial_value: 1.0.1, default_enabled: true, type: STANDARD}, feature_state_value: 2.0.0, enabled: true, environment: 7822, identity: null, feature_segment: null}, {id: 48547, feature: {id: 9371, name: my_feature, created_date: 2021-05-24T08:39:24.938442Z, description: My feature, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: my_feature_value, enabled: true, environment: 7822, identity: null, feature_segment: null}, {id: 48549, feature: {id: 9372, name: show_title_logo, created_date: 2021-05-24T08:40:25.683907Z, description: Show logo in Navigation bar, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 52786, feature: {id: 10101, name: max_version, created_date: 2021-06-20T07:14:26.446931Z, description: Max version of package, initial_value: 3.0.0, default_enabled: false, type: STANDARD}, feature_state_value: 3.0.0, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 58, feature: {id: 24, name: try_it, created_date: 2018-06-15T11:01:46.018370Z, description: Try it panels, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 5815, feature: {id: 1530, name: segment_operators, created_date: 2019-10-07T16:25:47.073428Z, description: Determines what rules are shown when creating a segment, initial_value: [
  {
    "value": "EQUAL",
    "label": "Exactly Matches (=)"
  },
  {
    "value": "NOT_EQUAL",
    "label": "Does not match (!=)"
  },
  {
    "value": "PERCENTAGE_SPLIT",
    "label": "% Split"
  },
  {
    "value": "GREATER_THAN",
    "label": ">"
  },
  {
    "value": "GREATER_THAN_INCLUSIVE",
    "label": ">="
  },
  {
    "value": "LESS_THAN",
    "label": "<"
  },
  {
    "value": "LESS_THAN_INCLUSIVE",
    "label": "<="
  },
  {
    "value": "CONTAINS",
    "label": "Contains"
  },
  {
    "value": "NOT_CONTAINS",
    "label": "Does not contain"
  },
  {
    "value": "REGEX",
    "label": "Matches regex"
  }
], default_enabled: false, type: STANDARD}, feature_state_value: [
  {
    "value": "EQUAL",
    "label": "Exactly Matches (=)"
  },
  {
    "value": "NOT_EQUAL",
    "label": "Does not match (!=)"
  },
  {
    "value": "PERCENTAGE_SPLIT",
    "label": "% Split"
  },
  {
    "value": "GREATER_THAN",
    "label": ">"
  },
  {
    "value": "GREATER_THAN_INCLUSIVE",
    "label": ">="
  },
  {
    "value": "LESS_THAN",
    "label": "<"
  },
  {
    "value": "LESS_THAN_INCLUSIVE",
    "label": "<="
  },
  {
    "value": "CONTAINS",
    "label": "Contains"
  },
  {
    "value": "NOT_CONTAINS",
    "label": "Does not contain"
  },
  {
    "value": "REGEX",
    "label": "Matches regex"
  }
], enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 9209, feature: {id: 2201, name: demo_link_color, created_date: 2020-01-29T14:55:06.097715Z, description: Colour of demo feature, initial_value: blue, default_enabled: false, type: STANDARD}, feature_state_value: white2, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 11065, feature: {id: 2509, name: demo_feature, created_date: 2020-03-07T17:30:47.410158Z, description: Shows a demo feature in the side navigation bar, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 12307, feature: {id: 2712, name: oauth_github, created_date: 2020-03-28T21:04:37.376577Z, description: GitHub login key, initial_value: {
  "url": "https://github.com/login/oauth/authorize?scope=user&client_id=5d99dd45d6cdf4a4ac61&redirect_uri=https%3A%2F%2Fdev.bullet-train.io%2Foauth%2Fgithub"
}, default_enabled: true, type: STANDARD}, feature_state_value: {
  "url": "https://github.com/login/oauth/authorize?scope=user&client_id=5d99dd45d6cdf4a4ac61&redirect_uri=https%3A%2F%2Fdev.bullet-train.io%2Foauth%2Fgithub"
}, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 12310, feature: {id: 2713, name: oauth_google, created_date: 2020-03-28T21:04:51.557946Z, description: Google login key, initial_value: {
 "clientId":"*****9427810-*****nrgouktp0ngsbs04o14ueb*****.apps.googleusercontent.com",
 "apiKey":"AIza****HuN-y6B********SXaz3X9GpEP*****"
}, default_enabled: false, type: STANDARD}, feature_state_value: {
 "clientId":"*****9427810-*****nrgouktp0ngsbs04o14ueb*****.apps.googleusercontent.com",
 "apiKey":"AIza****HuN-y6B********SXaz3X9GpEP*****"
}, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 12313, feature: {id: 2714, name: oauth_facebook, created_date: 2020-03-28T21:05:00.766672Z, description: Soon TM, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 12316, feature: {id: 2715, name: oauth_microsoft, created_date: 2020-03-28T21:05:13.100534Z, description: Soon TM, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: , enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 27322, feature: {id: 5538, name: plan_based_access, created_date: 2020-11-04T10:50:21.174891Z, description: Controls rbac and 2f based on plans, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 27418, feature: {id: 5560, name: integrations, created_date: 2020-11-05T16:52:57.918094Z, description: Defines the integrations we display, initial_value: ["amplitude", "datadog"], default_enabled: false, type: STANDARD}, feature_state_value: ["amplitude","datadog","new-relic","segment","heap","mixpanel"], enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 27481, feature: {id: 5564, name: integration_data, created_date: 2020-11-06T20:17:13.139643Z, description: Integration config for different providers, initial_value: {
  "datadog": {
    "perEnvironment": false,
    "image": "https://www.vectorlogo.zone/logos/datadoghq/datadoghq-icon.svg",
    "fields": [
      {
        "key": "base_url",
        "label": "Base URL"
      },
      {
        "key": "api_key",
        "label": "API Key"
      }
    ],
    "tags": [
      "logging"
    ],
    "title": "Data dog",
    "description": "Sends events to Data dog for when flags are created, updated and removed. Logs are tagged with the environment they came from e.g. production."
  },
  "amplitude": {
    "perEnvironment": true,
    "image": "https://braze-marketing-assets.s3.amazonaws.com/images/partner_logos/amplitude-1.png",
    "fields": [
      {
        "key": "api_key",
        "label": "API Key"
      }
    ],
    "tags": [
      "analytics"
    ],
    "title": "Amplitude",
    "description": "Sends data on what flags served to each identity."
  }
}, default_enabled: false, type: STANDARD}, feature_state_value: {
    "datadog": {
        "perEnvironment": false,
        "image": "https://app.flagsmith.com/images/integrations/datadog.svg",
        "docs": "https://docs.flagsmith.com/integrations/datadog/",
        "fields": [{
            "key": "base_url",
            "label": "Base URL"
        }, {
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["logging"],
        "title": "Datadog",
        "description": "Sends events to Datadog for when flags are created, updated and removed. Logs are tagged with the environment they came from e.g. production."
    },
    "amplitude": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/amplitude.svg",
        "docs": "https://docs.flagsmith.com/integrations/amplitude/",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Amplitude",
        "description": "Sends data on what flags served to each identity."
    },
    "new-relic": {
        "perEnvironment": false,
        "image": "https://app.flagsmith.com/images/integrations/new_relic.svg",
        "docs": "https://docs.flagsmith.com/integrations/newrelic",
        "fields": [{
            "key": "base_url",
            "label": "New Relic Base URL"
        }, {
            "key": "api_key",
            "label": "New Relic API Key"
        }, {
            "key": "app_id",
            "label": "New Relic Application ID"
        }],
        "tags": ["analytics"],
        "title": "New Relic",
        "description": "Sends events to New Relic for when flags are created, updated and removed."
    },
    "segment": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/segment.svg",
        "docs": "https://docs.flagsmith.com/integrations/segment",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Segment",
        "description": "Sends data on what flags served to each identity."
    },"heap": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/heap.svg",
        "docs": "https://docs.flagsmith.com/integrations/heap",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Heap Analytics",
        "description": "Sends data on what flags served to each identity."
    },"mixpanel": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/mixpanel.svg",
        "docs": "https://docs.flagsmith.com/integrations/mixpanel",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Mixpanel",
        "description": "Sends data on what flags served to each identity."
    }
}, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 29558, feature: {id: 6006, name: usage_chart, created_date: 2020-11-28T11:36:45.715798Z, description: Display influx usage chart and number, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 34292, feature: {id: 6903, name: scaleup_audit, created_date: 2021-01-27T20:41:28.931473Z, description: Disables audit log for anyone under scaleup, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 35671, feature: {id: 7168, name: butter_bar, created_date: 2021-02-10T20:03:43.348556Z, description: Show html in a butter bar for certain users, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: <strong>
You are using the develop environment.
</strong>, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 37186, feature: {id: 7460, name: flag_analytics, created_date: 2021-02-23T18:53:11.138355Z, description: Surface analytics when viewing a flag, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 41662, feature: {id: 8266, name: dark_mode, created_date: 2021-03-28T11:18:17.782264Z, description: Controlled via segments, determines if the user has dark mode on, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 44942, feature: {id: 8798, name: read_only_mode, created_date: 2021-04-24T10:17:23.574373Z, description: Determines if org needs to contact sales, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 53307, feature: {id: 10202, name: saml, created_date: 2021-06-23T17:40:39.556589Z, description: Enables SAML auth, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 59621, feature: {id: 11243, name: clone_environment, created_date: 2021-08-02T12:13:36.234860Z, description: adds the ability to clone an environment, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 62248, feature: {id: 11639, name: payments_enabled, created_date: 2021-08-15T15:42:53.454540Z, description: Determines whether to show payment UI / seats, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 62798, feature: {id: 11727, name: disable_create_org, created_date: 2021-08-16T17:18:28.052286Z, description: Turning this on will prevent users from creating any additional organisations, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}]

_createSubject fake_disabled_feature -> F(fake_disabled_feature:false)
_createSubject disabled_feature -> F(disabled_feature:false)
_updateSubject enabled_feature -> true f: true
_createSubject min_version -> F(min_version:true)
_updateSubject my_feature -> true f: true
_createSubject show_title_logo -> F(show_title_logo:false)
_createSubject max_version -> F(max_version:false)
_createSubject try_it -> F(try_it:true)
_createSubject segment_operators -> F(segment_operators:true)
_createSubject demo_link_color -> F(demo_link_color:true)
_createSubject demo_feature -> F(demo_feature:false)
_createSubject oauth_github -> F(oauth_github:true)
_createSubject oauth_google -> F(oauth_google:true)
_createSubject oauth_facebook -> F(oauth_facebook:true)
_createSubject oauth_microsoft -> F(oauth_microsoft:true)
_createSubject plan_based_access -> F(plan_based_access:true)
_createSubject integrations -> F(integrations:true)
00:05 +100 ~1: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_analytics_test.dart: [Analytics] Settings When starts client analytics are enabled as default
_createSubject integration_data -> F(integration_data:true)
_createSubject usage_chart -> F(usage_chart:true)
_createSubject scaleup_audit -> F(scaleup_audit:false)
_createSubject butter_bar -> F(butter_bar:true)
_createSubject flag_analytics -> F(flag_analytics:true)
_createSubject dark_mode -> F(dark_mode:false)
_createSubject read_only_mode -> F(read_only_mode:false)
_createSubject saml -> F(saml:true)
_createSubject clone_environment -> F(clone_environment:false)
_createSubject payments_enabled -> F(payments_enabled:true)
_createSubject disable_create_org -> F(disable_create_org:false)
00:05 +101 ~1: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_analytics_test.dart: [Analytics] Settings When starts client analytics are empty             
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
*** Request ***
uri: https://offline.net/flags/
method: GET
responseType: ResponseType.json
followRedirects: true
persistentConnection: true
connectTimeout: 0:00:10.000000
sendTimeout: 0:00:20.000000
receiveTimeout: 0:00:20.000000
receiveDataWhenStatusError: true
extra: {}
headers:
 X-Environment-Key: CoJErJUXmihfMDVwTzBff4_fake
 Accept: application/json
data:
null

00:05 +110 ~1: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_analytics_test.dart: [Analytics] Settings When starts client analytics are empty             
*** Response ***
uri: https://offline.net/flags/
statusCode: 200
headers:
 content-type: application/json
Response Text:
[{id: 48540, feature: {id: 9368, name: fake_disabled_feature, created_date: 2021-05-24T08:38:29.203517Z, description: Fake Disabled feature, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 48541, feature: {id: 9368, name: disabled_feature, created_date: 2021-05-24T08:38:29.203517Z, description: Disabled feature, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 48543, feature: {id: 9369, name: enabled_feature, created_date: 2021-05-24T08:38:47.375641Z, description: Enabled test feature, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 7822, identity: null, feature_segment: null}, {id: 48545, feature: {id: 9370, name: min_version, created_date: 2021-05-24T08:39:05.095219Z, description: test min version, initial_value: 1.0.1, default_enabled: true, type: STANDARD}, feature_state_value: 2.0.0, enabled: true, environment: 7822, identity: null, feature_segment: null}, {id: 48547, feature: {id: 9371, name: my_feature, created_date: 2021-05-24T08:39:24.938442Z, description: My feature, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: my_feature_value, enabled: true, environment: 7822, identity: null, feature_segment: null}, {id: 48549, feature: {id: 9372, name: show_title_logo, created_date: 2021-05-24T08:40:25.683907Z, description: Show logo in Navigation bar, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 52786, feature: {id: 10101, name: max_version, created_date: 2021-06-20T07:14:26.446931Z, description: Max version of package, initial_value: 3.0.0, default_enabled: false, type: STANDARD}, feature_state_value: 3.0.0, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 58, feature: {id: 24, name: try_it, created_date: 2018-06-15T11:01:46.018370Z, description: Try it panels, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 5815, feature: {id: 1530, name: segment_operators, created_date: 2019-10-07T16:25:47.073428Z, description: Determines what rules are shown when creating a segment, initial_value: [
  {
    "value": "EQUAL",
    "label": "Exactly Matches (=)"
  },
  {
    "value": "NOT_EQUAL",
    "label": "Does not match (!=)"
  },
  {
    "value": "PERCENTAGE_SPLIT",
    "label": "% Split"
  },
  {
    "value": "GREATER_THAN",
    "label": ">"
  },
  {
    "value": "GREATER_THAN_INCLUSIVE",
    "label": ">="
  },
  {
    "value": "LESS_THAN",
    "label": "<"
  },
  {
    "value": "LESS_THAN_INCLUSIVE",
    "label": "<="
  },
  {
    "value": "CONTAINS",
    "label": "Contains"
  },
  {
    "value": "NOT_CONTAINS",
    "label": "Does not contain"
  },
  {
    "value": "REGEX",
    "label": "Matches regex"
  }
], default_enabled: false, type: STANDARD}, feature_state_value: [
  {
    "value": "EQUAL",
    "label": "Exactly Matches (=)"
  },
  {
    "value": "NOT_EQUAL",
    "label": "Does not match (!=)"
  },
  {
    "value": "PERCENTAGE_SPLIT",
    "label": "% Split"
  },
  {
    "value": "GREATER_THAN",
    "label": ">"
  },
  {
    "value": "GREATER_THAN_INCLUSIVE",
    "label": ">="
  },
  {
    "value": "LESS_THAN",
    "label": "<"
  },
  {
    "value": "LESS_THAN_INCLUSIVE",
    "label": "<="
  },
  {
    "value": "CONTAINS",
    "label": "Contains"
  },
  {
    "value": "NOT_CONTAINS",
    "label": "Does not contain"
  },
  {
    "value": "REGEX",
    "label": "Matches regex"
  }
], enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 9209, feature: {id: 2201, name: demo_link_color, created_date: 2020-01-29T14:55:06.097715Z, description: Colour of demo feature, initial_value: blue, default_enabled: false, type: STANDARD}, feature_state_value: white2, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 11065, feature: {id: 2509, name: demo_feature, created_date: 2020-03-07T17:30:47.410158Z, description: Shows a demo feature in the side navigation bar, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 12307, feature: {id: 2712, name: oauth_github, created_date: 2020-03-28T21:04:37.376577Z, description: GitHub login key, initial_value: {
  "url": "https://github.com/login/oauth/authorize?scope=user&client_id=5d99dd45d6cdf4a4ac61&redirect_uri=https%3A%2F%2Fdev.bullet-train.io%2Foauth%2Fgithub"
}, default_enabled: true, type: STANDARD}, feature_state_value: {
  "url": "https://github.com/login/oauth/authorize?scope=user&client_id=5d99dd45d6cdf4a4ac61&redirect_uri=https%3A%2F%2Fdev.bullet-train.io%2Foauth%2Fgithub"
}, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 12310, feature: {id: 2713, name: oauth_google, created_date: 2020-03-28T21:04:51.557946Z, description: Google login key, initial_value: {
 "clientId":"*****9427810-*****nrgouktp0ngsbs04o14ueb*****.apps.googleusercontent.com",
 "apiKey":"AIza****HuN-y6B********SXaz3X9GpEP*****"
}, default_enabled: false, type: STANDARD}, feature_state_value: {
 "clientId":"*****9427810-*****nrgouktp0ngsbs04o14ueb*****.apps.googleusercontent.com",
 "apiKey":"AIza****HuN-y6B********SXaz3X9GpEP*****"
}, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 12313, feature: {id: 2714, name: oauth_facebook, created_date: 2020-03-28T21:05:00.766672Z, description: Soon TM, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 12316, feature: {id: 2715, name: oauth_microsoft, created_date: 2020-03-28T21:05:13.100534Z, description: Soon TM, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: , enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 27322, feature: {id: 5538, name: plan_based_access, created_date: 2020-11-04T10:50:21.174891Z, description: Controls rbac and 2f based on plans, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 27418, feature: {id: 5560, name: integrations, created_date: 2020-11-05T16:52:57.918094Z, description: Defines the integrations we display, initial_value: ["amplitude", "datadog"], default_enabled: false, type: STANDARD}, feature_state_value: ["amplitude","datadog","new-relic","segment","heap","mixpanel"], enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 27481, feature: {id: 5564, name: integration_data, created_date: 2020-11-06T20:17:13.139643Z, description: Integration config for different providers, initial_value: {
  "datadog": {
    "perEnvironment": false,
    "image": "https://www.vectorlogo.zone/logos/datadoghq/datadoghq-icon.svg",
    "fields": [
      {
        "key": "base_url",
        "label": "Base URL"
      },
      {
        "key": "api_key",
        "label": "API Key"
      }
    ],
    "tags": [
      "logging"
    ],
    "title": "Data dog",
    "description": "Sends events to Data dog for when flags are created, updated and removed. Logs are tagged with the environment they came from e.g. production."
  },
  "amplitude": {
    "perEnvironment": true,
    "image": "https://braze-marketing-assets.s3.amazonaws.com/images/partner_logos/amplitude-1.png",
    "fields": [
      {
        "key": "api_key",
        "label": "API Key"
      }
    ],
    "tags": [
      "analytics"
    ],
    "title": "Amplitude",
    "description": "Sends data on what flags served to each identity."
  }
}, default_enabled: false, type: STANDARD}, feature_state_value: {
    "datadog": {
        "perEnvironment": false,
        "image": "https://app.flagsmith.com/images/integrations/datadog.svg",
        "docs": "https://docs.flagsmith.com/integrations/datadog/",
        "fields": [{
            "key": "base_url",
            "label": "Base URL"
        }, {
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["logging"],
        "title": "Datadog",
        "description": "Sends events to Datadog for when flags are created, updated and removed. Logs are tagged with the environment they came from e.g. production."
    },
    "amplitude": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/amplitude.svg",
        "docs": "https://docs.flagsmith.com/integrations/amplitude/",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Amplitude",
        "description": "Sends data on what flags served to each identity."
    },
    "new-relic": {
        "perEnvironment": false,
        "image": "https://app.flagsmith.com/images/integrations/new_relic.svg",
        "docs": "https://docs.flagsmith.com/integrations/newrelic",
        "fields": [{
            "key": "base_url",
            "label": "New Relic Base URL"
        }, {
            "key": "api_key",
            "label": "New Relic API Key"
        }, {
            "key": "app_id",
            "label": "New Relic Application ID"
        }],
        "tags": ["analytics"],
        "title": "New Relic",
        "description": "Sends events to New Relic for when flags are created, updated and removed."
    },
    "segment": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/segment.svg",
        "docs": "https://docs.flagsmith.com/integrations/segment",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Segment",
        "description": "Sends data on what flags served to each identity."
    },"heap": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/heap.svg",
        "docs": "https://docs.flagsmith.com/integrations/heap",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Heap Analytics",
        "description": "Sends data on what flags served to each identity."
    },"mixpanel": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/mixpanel.svg",
        "docs": "https://docs.flagsmith.com/integrations/mixpanel",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Mixpanel",
        "description": "Sends data on what flags served to each identity."
    }
}, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 29558, feature: {id: 6006, name: usage_chart, created_date: 2020-11-28T11:36:45.715798Z, description: Display influx usage chart and number, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 34292, feature: {id: 6903, name: scaleup_audit, created_date: 2021-01-27T20:41:28.931473Z, description: Disables audit log for anyone under scaleup, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 35671, feature: {id: 7168, name: butter_bar, created_date: 2021-02-10T20:03:43.348556Z, description: Show html in a butter bar for certain users, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: <strong>
You are using the develop environment.
</strong>, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 37186, feature: {id: 7460, name: flag_analytics, created_date: 2021-02-23T18:53:11.138355Z, description: Surface analytics when viewing a flag, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 41662, feature: {id: 8266, name: dark_mode, created_date: 2021-03-28T11:18:17.782264Z, description: Controlled via segments, determines if the user has dark mode on, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 44942, feature: {id: 8798, name: read_only_mode, created_date: 2021-04-24T10:17:23.574373Z, description: Determines if org needs to contact sales, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 53307, feature: {id: 10202, name: saml, created_date: 2021-06-23T17:40:39.556589Z, description: Enables SAML auth, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 59621, feature: {id: 11243, name: clone_environment, created_date: 2021-08-02T12:13:36.234860Z, description: adds the ability to clone an environment, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 62248, feature: {id: 11639, name: payments_enabled, created_date: 2021-08-15T15:42:53.454540Z, description: Determines whether to show payment UI / seats, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 62798, feature: {id: 11727, name: disable_create_org, created_date: 2021-08-16T17:18:28.052286Z, description: Turning this on will prevent users from creating any additional organisations, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}]

_createSubject fake_disabled_feature -> F(fake_disabled_feature:false)
_createSubject disabled_feature -> F(disabled_feature:false)
_updateSubject enabled_feature -> true f: true
_createSubject min_version -> F(min_version:true)
_updateSubject my_feature -> true f: true
_createSubject show_title_logo -> F(show_title_logo:false)
_createSubject max_version -> F(max_version:false)
_createSubject try_it -> F(try_it:true)
_createSubject segment_operators -> F(segment_operators:true)
_createSubject demo_link_color -> F(demo_link_color:true)
_createSubject demo_feature -> F(demo_feature:false)
_createSubject oauth_github -> F(oauth_github:true)
_createSubject oauth_google -> F(oauth_google:true)
_createSubject oauth_facebook -> F(oauth_facebook:true)
_createSubject oauth_microsoft -> F(oauth_microsoft:true)
_createSubject plan_based_access -> F(plan_based_access:true)
_createSubject integrations -> F(integrations:true)
_createSubject integration_data -> F(integration_data:true)
_createSubject usage_chart -> F(usage_chart:true)
_createSubject scaleup_audit -> F(scaleup_audit:false)
_createSubject butter_bar -> F(butter_bar:true)
_createSubject flag_analytics -> F(flag_analytics:true)
_createSubject dark_mode -> F(dark_mode:false)
_createSubject read_only_mode -> F(read_only_mode:false)
_createSubject saml -> F(saml:true)
_createSubject clone_environment -> F(clone_environment:false)
_createSubject payments_enabled -> F(payments_enabled:true)
_createSubject disable_create_org -> F(disable_create_org:false)
00:05 +111 ~1: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_analytics_test.dart: [Analytics] Settings When client check flag value, then increment value in map
_createSubject my_feature -> F(my_feature:true)
_createSubject enabled_feature -> F(enabled_feature:true)
_createSubject enabled_value -> F(enabled_value:true)
*** Request ***
uri: https://offline.net/flags/
method: GET
responseType: ResponseType.json
followRedirects: true
persistentConnection: true
connectTimeout: 0:00:10.000000
sendTimeout: 0:00:20.000000
receiveTimeout: 0:00:20.000000
receiveDataWhenStatusError: true
extra: {}
headers:
 X-Environment-Key: CoJErJUXmihfMDVwTzBff4_fake
 Accept: application/json
data:
null

00:05 +113 ~1: (REDACTED)/flagsmith-flutter-client/test/fg/flagsmith_analytics_test.dart: [Analytics] Settings When client check flag value, then increment value in map
*** Response ***
uri: https://offline.net/flags/
statusCode: 200
headers:
 content-type: application/json
Response Text:
[{id: 48540, feature: {id: 9368, name: fake_disabled_feature, created_date: 2021-05-24T08:38:29.203517Z, description: Fake Disabled feature, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 48541, feature: {id: 9368, name: disabled_feature, created_date: 2021-05-24T08:38:29.203517Z, description: Disabled feature, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 48543, feature: {id: 9369, name: enabled_feature, created_date: 2021-05-24T08:38:47.375641Z, description: Enabled test feature, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 7822, identity: null, feature_segment: null}, {id: 48545, feature: {id: 9370, name: min_version, created_date: 2021-05-24T08:39:05.095219Z, description: test min version, initial_value: 1.0.1, default_enabled: true, type: STANDARD}, feature_state_value: 2.0.0, enabled: true, environment: 7822, identity: null, feature_segment: null}, {id: 48547, feature: {id: 9371, name: my_feature, created_date: 2021-05-24T08:39:24.938442Z, description: My feature, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: my_feature_value, enabled: true, environment: 7822, identity: null, feature_segment: null}, {id: 48549, feature: {id: 9372, name: show_title_logo, created_date: 2021-05-24T08:40:25.683907Z, description: Show logo in Navigation bar, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 52786, feature: {id: 10101, name: max_version, created_date: 2021-06-20T07:14:26.446931Z, description: Max version of package, initial_value: 3.0.0, default_enabled: false, type: STANDARD}, feature_state_value: 3.0.0, enabled: false, environment: 7822, identity: null, feature_segment: null}, {id: 58, feature: {id: 24, name: try_it, created_date: 2018-06-15T11:01:46.018370Z, description: Try it panels, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 5815, feature: {id: 1530, name: segment_operators, created_date: 2019-10-07T16:25:47.073428Z, description: Determines what rules are shown when creating a segment, initial_value: [
  {
    "value": "EQUAL",
    "label": "Exactly Matches (=)"
  },
  {
    "value": "NOT_EQUAL",
    "label": "Does not match (!=)"
  },
  {
    "value": "PERCENTAGE_SPLIT",
    "label": "% Split"
  },
  {
    "value": "GREATER_THAN",
    "label": ">"
  },
  {
    "value": "GREATER_THAN_INCLUSIVE",
    "label": ">="
  },
  {
    "value": "LESS_THAN",
    "label": "<"
  },
  {
    "value": "LESS_THAN_INCLUSIVE",
    "label": "<="
  },
  {
    "value": "CONTAINS",
    "label": "Contains"
  },
  {
    "value": "NOT_CONTAINS",
    "label": "Does not contain"
  },
  {
    "value": "REGEX",
    "label": "Matches regex"
  }
], default_enabled: false, type: STANDARD}, feature_state_value: [
  {
    "value": "EQUAL",
    "label": "Exactly Matches (=)"
  },
  {
    "value": "NOT_EQUAL",
    "label": "Does not match (!=)"
  },
  {
    "value": "PERCENTAGE_SPLIT",
    "label": "% Split"
  },
  {
    "value": "GREATER_THAN",
    "label": ">"
  },
  {
    "value": "GREATER_THAN_INCLUSIVE",
    "label": ">="
  },
  {
    "value": "LESS_THAN",
    "label": "<"
  },
  {
    "value": "LESS_THAN_INCLUSIVE",
    "label": "<="
  },
  {
    "value": "CONTAINS",
    "label": "Contains"
  },
  {
    "value": "NOT_CONTAINS",
    "label": "Does not contain"
  },
  {
    "value": "REGEX",
    "label": "Matches regex"
  }
], enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 9209, feature: {id: 2201, name: demo_link_color, created_date: 2020-01-29T14:55:06.097715Z, description: Colour of demo feature, initial_value: blue, default_enabled: false, type: STANDARD}, feature_state_value: white2, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 11065, feature: {id: 2509, name: demo_feature, created_date: 2020-03-07T17:30:47.410158Z, description: Shows a demo feature in the side navigation bar, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 12307, feature: {id: 2712, name: oauth_github, created_date: 2020-03-28T21:04:37.376577Z, description: GitHub login key, initial_value: {
  "url": "https://github.com/login/oauth/authorize?scope=user&client_id=5d99dd45d6cdf4a4ac61&redirect_uri=https%3A%2F%2Fdev.bullet-train.io%2Foauth%2Fgithub"
}, default_enabled: true, type: STANDARD}, feature_state_value: {
  "url": "https://github.com/login/oauth/authorize?scope=user&client_id=5d99dd45d6cdf4a4ac61&redirect_uri=https%3A%2F%2Fdev.bullet-train.io%2Foauth%2Fgithub"
}, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 12310, feature: {id: 2713, name: oauth_google, created_date: 2020-03-28T21:04:51.557946Z, description: Google login key, initial_value: {
 "clientId":"*****9427810-*****nrgouktp0ngsbs04o14ueb*****.apps.googleusercontent.com",
 "apiKey":"AIza****HuN-y6B********SXaz3X9GpEP*****"
}, default_enabled: false, type: STANDARD}, feature_state_value: {
 "clientId":"*****9427810-*****nrgouktp0ngsbs04o14ueb*****.apps.googleusercontent.com",
 "apiKey":"AIza****HuN-y6B********SXaz3X9GpEP*****"
}, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 12313, feature: {id: 2714, name: oauth_facebook, created_date: 2020-03-28T21:05:00.766672Z, description: Soon TM, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 12316, feature: {id: 2715, name: oauth_microsoft, created_date: 2020-03-28T21:05:13.100534Z, description: Soon TM, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: , enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 27322, feature: {id: 5538, name: plan_based_access, created_date: 2020-11-04T10:50:21.174891Z, description: Controls rbac and 2f based on plans, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 27418, feature: {id: 5560, name: integrations, created_date: 2020-11-05T16:52:57.918094Z, description: Defines the integrations we display, initial_value: ["amplitude", "datadog"], default_enabled: false, type: STANDARD}, feature_state_value: ["amplitude","datadog","new-relic","segment","heap","mixpanel"], enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 27481, feature: {id: 5564, name: integration_data, created_date: 2020-11-06T20:17:13.139643Z, description: Integration config for different providers, initial_value: {
  "datadog": {
    "perEnvironment": false,
    "image": "https://www.vectorlogo.zone/logos/datadoghq/datadoghq-icon.svg",
    "fields": [
      {
        "key": "base_url",
        "label": "Base URL"
      },
      {
        "key": "api_key",
        "label": "API Key"
      }
    ],
    "tags": [
      "logging"
    ],
    "title": "Data dog",
    "description": "Sends events to Data dog for when flags are created, updated and removed. Logs are tagged with the environment they came from e.g. production."
  },
  "amplitude": {
    "perEnvironment": true,
    "image": "https://braze-marketing-assets.s3.amazonaws.com/images/partner_logos/amplitude-1.png",
    "fields": [
      {
        "key": "api_key",
        "label": "API Key"
      }
    ],
    "tags": [
      "analytics"
    ],
    "title": "Amplitude",
    "description": "Sends data on what flags served to each identity."
  }
}, default_enabled: false, type: STANDARD}, feature_state_value: {
    "datadog": {
        "perEnvironment": false,
        "image": "https://app.flagsmith.com/images/integrations/datadog.svg",
        "docs": "https://docs.flagsmith.com/integrations/datadog/",
        "fields": [{
            "key": "base_url",
            "label": "Base URL"
        }, {
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["logging"],
        "title": "Datadog",
        "description": "Sends events to Datadog for when flags are created, updated and removed. Logs are tagged with the environment they came from e.g. production."
    },
    "amplitude": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/amplitude.svg",
        "docs": "https://docs.flagsmith.com/integrations/amplitude/",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Amplitude",
        "description": "Sends data on what flags served to each identity."
    },
    "new-relic": {
        "perEnvironment": false,
        "image": "https://app.flagsmith.com/images/integrations/new_relic.svg",
        "docs": "https://docs.flagsmith.com/integrations/newrelic",
        "fields": [{
            "key": "base_url",
            "label": "New Relic Base URL"
        }, {
            "key": "api_key",
            "label": "New Relic API Key"
        }, {
            "key": "app_id",
            "label": "New Relic Application ID"
        }],
        "tags": ["analytics"],
        "title": "New Relic",
        "description": "Sends events to New Relic for when flags are created, updated and removed."
    },
    "segment": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/segment.svg",
        "docs": "https://docs.flagsmith.com/integrations/segment",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Segment",
        "description": "Sends data on what flags served to each identity."
    },"heap": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/heap.svg",
        "docs": "https://docs.flagsmith.com/integrations/heap",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Heap Analytics",
        "description": "Sends data on what flags served to each identity."
    },"mixpanel": {
        "perEnvironment": true,
        "image": "https://app.flagsmith.com/images/integrations/mixpanel.svg",
        "docs": "https://docs.flagsmith.com/integrations/mixpanel",
        "fields": [{
            "key": "api_key",
            "label": "API Key"
        }],
        "tags": ["analytics"],
        "title": "Mixpanel",
        "description": "Sends data on what flags served to each identity."
    }
}, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 29558, feature: {id: 6006, name: usage_chart, created_date: 2020-11-28T11:36:45.715798Z, description: Display influx usage chart and number, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 34292, feature: {id: 6903, name: scaleup_audit, created_date: 2021-01-27T20:41:28.931473Z, description: Disables audit log for anyone under scaleup, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 35671, feature: {id: 7168, name: butter_bar, created_date: 2021-02-10T20:03:43.348556Z, description: Show html in a butter bar for certain users, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: <strong>
You are using the develop environment.
</strong>, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 37186, feature: {id: 7460, name: flag_analytics, created_date: 2021-02-23T18:53:11.138355Z, description: Surface analytics when viewing a flag, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 41662, feature: {id: 8266, name: dark_mode, created_date: 2021-03-28T11:18:17.782264Z, description: Controlled via segments, determines if the user has dark mode on, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 44942, feature: {id: 8798, name: read_only_mode, created_date: 2021-04-24T10:17:23.574373Z, description: Determines if org needs to contact sales, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 53307, feature: {id: 10202, name: saml, created_date: 2021-06-23T17:40:39.556589Z, description: Enables SAML auth, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 59621, feature: {id: 11243, name: clone_environment, created_date: 2021-08-02T12:13:36.234860Z, description: adds the ability to clone an environment, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}, {id: 62248, feature: {id: 11639, name: payments_enabled, created_date: 2021-08-15T15:42:53.454540Z, description: Determines whether to show payment UI / seats, initial_value: null, default_enabled: true, type: STANDARD}, feature_state_value: null, enabled: true, environment: 23, identity: null, feature_segment: null}, {id: 62798, feature: {id: 11727, name: disable_create_org, created_date: 2021-08-16T17:18:28.052286Z, description: Turning this on will prevent users from creating any additional organisations, initial_value: null, default_enabled: false, type: STANDARD}, feature_state_value: null, enabled: false, environment: 23, identity: null, feature_segment: null}]

_createSubject fake_disabled_feature -> F(fake_disabled_feature:false)
_createSubject disabled_feature -> F(disabled_feature:false)
_updateSubject enabled_feature -> true f: true
_createSubject min_version -> F(min_version:true)
_updateSubject my_feature -> true f: true
_createSubject show_title_logo -> F(show_title_logo:false)
_createSubject max_version -> F(max_version:false)
_createSubject try_it -> F(try_it:true)
_createSubject segment_operators -> F(segment_operators:true)
_createSubject demo_link_color -> F(demo_link_color:true)
_createSubject demo_feature -> F(demo_feature:false)
_createSubject oauth_github -> F(oauth_github:true)
_createSubject oauth_google -> F(oauth_google:true)
_createSubject oauth_facebook -> F(oauth_facebook:true)
_createSubject oauth_microsoft -> F(oauth_microsoft:true)
_createSubject plan_based_access -> F(plan_based_access:true)
_createSubject integrations -> F(integrations:true)
_createSubject integration_data -> F(integration_data:true)
_createSubject usage_chart -> F(usage_chart:true)
_createSubject scaleup_audit -> F(scaleup_audit:false)
_createSubject butter_bar -> F(butter_bar:true)
_createSubject flag_analytics -> F(flag_analytics:true)
_createSubject dark_mode -> F(dark_mode:false)
_createSubject read_only_mode -> F(read_only_mode:false)
_createSubject saml -> F(saml:true)
_createSubject clone_environment -> F(clone_environment:false)
_createSubject payments_enabled -> F(payments_enabled:true)
_createSubject disable_create_org -> F(disable_create_org:false)
00:06 +119 ~1: All tests passed!                                                                                                                                                 
```
</details>