### PR TITLE
fix(ci): Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Publish
         run: |
           flutter pub pub token add https://pub.dev --env-var PUB_TOKEN
-          flutter pub publish
+          flutter pub publish --force


### PR DESCRIPTION
This workflow was never run before so I don't think this ever worked: https://github.com/Flagsmith/flagsmith-flutter-client/actions/runs/13772364290/job/38513704635#step:5:399

From `flutter pub publish --help`:

```                                                                
-f, --force              Publish without confirmation if there are no errors.
```