### PR TITLE
♻️ (refactor): noisy dio debug logs on web #67

### DIFF
--- a/lib/src/flagsmith_config.dart
+++ b/lib/src/flagsmith_config.dart
@@ -1,5 +1,7 @@
-import '../flagsmith.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../flagsmith.dart';
 
 /// Default definition of connection to API
 class FlagsmithConfig {
@@ -76,6 +78,6 @@ class FlagsmithConfig {
         baseUrl: baseURI,
         connectTimeout: Duration(milliseconds: connectTimeout),
         receiveTimeout: Duration(milliseconds: receiveTimeout),
-        sendTimeout: Duration(milliseconds: sendTimeout),
+        sendTimeout: kIsWeb ? null : Duration(milliseconds: sendTimeout),
       );
 }


### PR DESCRIPTION
The sendTimeout was being applied to ALL requests, including GET requests which don't have a request body. On the web platform, Dio correctly warns that sendTimeout should only be used with requests that have a **body** to send.

### Fixes : 
* Modified the `sendTimeout` property in the `FlagsmithConfig` class to set it to `null` when running on web platforms (`kIsWeb`), ensuring compatibility with environments where timeouts may not be applicable.


Logs (before vs after) :
![flagsmith2](https://github.com/user-attachments/assets/3a2f014e-3a89-44d2-8484-08fc9f71dc0b)

![flagsmith1](https://github.com/user-attachments/assets/2dd2ef0d-028a-47cc-bcd8-726a6328a575)
